### PR TITLE
feat(T003.1.2): create desktop-app/tsconfig.json with strict mode

### DIFF
--- a/desktop-app/tsconfig.json
+++ b/desktop-app/tsconfig.json
@@ -1,0 +1,54 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "@main/*": ["src/main/*"],
+      "@renderer/*": ["src/renderer/*"]
+    },
+
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "release"
+  ]
+}

--- a/log_files/T003.1.2_Create_tsconfig_Log.md
+++ b/log_files/T003.1.2_Create_tsconfig_Log.md
@@ -1,0 +1,108 @@
+# Implementation Log: T003.1.2 - Create desktop-app/tsconfig.json with strict mode
+
+## Task Information
+- **Task ID**: T003.1.2
+- **Task Name**: Create `desktop-app/tsconfig.json` with strict mode
+- **Parent Task**: T003.1 - Create Electron/React project
+- **Date**: 2025-12-16
+- **Status**: ✅ Completed
+
+## Implementation Details
+
+### Objective
+Create TypeScript configuration file with strict type checking for the Electron/React desktop application.
+
+### File Created
+
+**Location**: `desktop-app/tsconfig.json`
+
+### Compiler Options Configured
+
+#### Target and Module Settings
+
+| Option | Value | Purpose |
+|--------|-------|---------|
+| target | ES2022 | Modern JavaScript features |
+| lib | ES2022, DOM, DOM.Iterable | Available APIs |
+| module | ESNext | ES modules |
+| moduleResolution | bundler | Vite/bundler resolution |
+| jsx | react-jsx | React 17+ JSX transform |
+
+#### Strict Mode Settings
+
+| Option | Value | Purpose |
+|--------|-------|---------|
+| strict | true | Enable all strict checks |
+| noImplicitAny | true | Error on implied any |
+| strictNullChecks | true | Strict null/undefined |
+| strictFunctionTypes | true | Function type checking |
+| strictBindCallApply | true | Bind/call/apply checking |
+| strictPropertyInitialization | true | Class property init |
+| noImplicitThis | true | Error on implied this |
+| alwaysStrict | true | Emit "use strict" |
+
+#### Additional Checks
+
+| Option | Value | Purpose |
+|--------|-------|---------|
+| noUnusedLocals | true | Error on unused variables |
+| noUnusedParameters | true | Error on unused params |
+| noImplicitReturns | true | All paths must return |
+| noFallthroughCasesInSwitch | true | Switch case fallthrough |
+| noUncheckedIndexedAccess | true | Index access returns T \| undefined |
+
+#### Module Interop
+
+| Option | Value | Purpose |
+|--------|-------|---------|
+| esModuleInterop | true | CommonJS/ES module compat |
+| allowSyntheticDefaultImports | true | Allow default imports |
+| forceConsistentCasingInFileNames | true | Case-sensitive imports |
+| resolveJsonModule | true | Import JSON files |
+| isolatedModules | true | Per-file transpilation |
+| skipLibCheck | true | Skip .d.ts checking |
+
+#### Path Aliases
+
+```json
+{
+  "paths": {
+    "@/*": ["src/*"],
+    "@main/*": ["src/main/*"],
+    "@renderer/*": ["src/renderer/*"]
+  }
+}
+```
+
+### Include/Exclude Patterns
+
+```json
+{
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "dist", "release"]
+}
+```
+
+### Design Decisions
+
+1. **ES2022 target**: Modern features, Electron supports recent V8
+2. **ESNext module**: Works with Vite bundler
+3. **react-jsx**: Modern JSX transform (no React import needed)
+4. **Full strict mode**: Maximum type safety
+5. **Path aliases**: Clean imports (@main/*, @renderer/*)
+6. **skipLibCheck**: Faster builds, trust library types
+
+### Verification
+- All 11 tests passed successfully
+- JSON is valid and parseable
+- All strict options enabled
+- Module settings appropriate for Electron + Vite
+
+## Related Files
+- Test file: `tests/desktop_app/test_T003_1_2_tsconfig.py`
+- Test log: `log_tests/T003.1.2_Create_tsconfig_TestLog.md`
+- Learn guide: `log_learn/T003.1.2_Create_tsconfig_Guide.md`
+
+## Next Steps
+- T003.1.3: Create `desktop-app/tailwind.config.js`
+- T003.1.4: Create `desktop-app/electron-builder.json`

--- a/log_learn/T003.1.2_Create_tsconfig_Guide.md
+++ b/log_learn/T003.1.2_Create_tsconfig_Guide.md
@@ -1,0 +1,321 @@
+# Learning Guide: T003.1.2 - TypeScript Configuration
+
+## What is tsconfig.json?
+
+`tsconfig.json` is the TypeScript compiler configuration file. It defines:
+- How TypeScript code is compiled
+- Type checking strictness
+- Module resolution strategy
+- Output settings
+
+## TypeScript Strict Mode
+
+### The `strict` Flag
+
+When `strict: true`, TypeScript enables ALL strict type-checking options:
+
+```json
+{
+  "compilerOptions": {
+    "strict": true
+    // Equivalent to enabling all of these:
+    // "noImplicitAny": true,
+    // "strictNullChecks": true,
+    // "strictFunctionTypes": true,
+    // "strictBindCallApply": true,
+    // "strictPropertyInitialization": true,
+    // "noImplicitThis": true,
+    // "alwaysStrict": true
+  }
+}
+```
+
+### What Each Strict Option Does
+
+#### noImplicitAny
+
+```typescript
+// Error without noImplicitAny
+function greet(name) {  // 'name' implicitly has 'any' type
+  return `Hello, ${name}`;
+}
+
+// Correct
+function greet(name: string): string {
+  return `Hello, ${name}`;
+}
+```
+
+#### strictNullChecks
+
+```typescript
+// Without strictNullChecks - dangerous!
+let name: string = null;  // OK (but unsafe)
+
+// With strictNullChecks
+let name: string = null;  // Error!
+let name: string | null = null;  // OK - explicit null
+```
+
+#### strictFunctionTypes
+
+```typescript
+type Handler = (x: string) => void;
+
+// Without strictFunctionTypes
+const handler: Handler = (x: string | number) => {};  // OK (unsound)
+
+// With strictFunctionTypes
+const handler: Handler = (x: string | number) => {};  // Error!
+```
+
+## Module Configuration
+
+### target vs module
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",  // JavaScript version to emit
+    "module": "ESNext"   // Module system to use
+  }
+}
+```
+
+| Setting | Purpose |
+|---------|---------|
+| target | JavaScript features to use (ES5, ES2022, ESNext) |
+| module | Module format (CommonJS, ESNext, NodeNext) |
+
+### moduleResolution
+
+```json
+{
+  "compilerOptions": {
+    "moduleResolution": "bundler"  // For Vite/webpack
+    // "moduleResolution": "node"   // For Node.js
+    // "moduleResolution": "nodenext" // For Node.js ESM
+  }
+}
+```
+
+## JSX Configuration
+
+### React 17+ (New JSX Transform)
+
+```json
+{
+  "compilerOptions": {
+    "jsx": "react-jsx"  // No need to import React
+  }
+}
+```
+
+```tsx
+// With react-jsx, no React import needed
+function Button() {
+  return <button>Click me</button>;
+}
+```
+
+### React 16 (Classic)
+
+```json
+{
+  "compilerOptions": {
+    "jsx": "react"  // Requires React import
+  }
+}
+```
+
+```tsx
+// With react, must import React
+import React from 'react';
+
+function Button() {
+  return <button>Click me</button>;
+}
+```
+
+## Path Aliases
+
+### Configuration
+
+```json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "@main/*": ["src/main/*"],
+      "@renderer/*": ["src/renderer/*"]
+    }
+  }
+}
+```
+
+### Usage
+
+```typescript
+// Instead of relative paths
+import { Button } from '../../../components/Button';
+
+// Use aliases
+import { Button } from '@renderer/components/Button';
+```
+
+### Vite Configuration (Required)
+
+```javascript
+// vite.config.ts
+import { resolve } from 'path';
+
+export default {
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+      '@main': resolve(__dirname, 'src/main'),
+      '@renderer': resolve(__dirname, 'src/renderer'),
+    }
+  }
+}
+```
+
+## Electron-Specific Configuration
+
+### Main Process (Node.js)
+
+```json
+// tsconfig.main.json
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "dist/main"
+  },
+  "include": ["src/main/**/*"]
+}
+```
+
+### Renderer Process (Browser)
+
+```json
+// tsconfig.renderer.json
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "outDir": "dist/renderer"
+  },
+  "include": ["src/renderer/**/*"]
+}
+```
+
+## Important Options Explained
+
+### esModuleInterop
+
+Allows importing CommonJS modules with default import:
+
+```typescript
+// Without esModuleInterop
+import * as fs from 'fs';
+
+// With esModuleInterop
+import fs from 'fs';  // Cleaner syntax
+```
+
+### skipLibCheck
+
+```json
+{
+  "compilerOptions": {
+    "skipLibCheck": true  // Skip type checking .d.ts files
+  }
+}
+```
+
+- Faster compilation
+- Avoids conflicts between library types
+- Recommended for most projects
+
+### resolveJsonModule
+
+```typescript
+// With resolveJsonModule: true
+import packageJson from './package.json';
+console.log(packageJson.version);
+```
+
+### isolatedModules
+
+```json
+{
+  "compilerOptions": {
+    "isolatedModules": true  // Required for Vite/esbuild
+  }
+}
+```
+
+Ensures each file can be transpiled independently.
+
+## Our Configuration Structure
+
+```json
+{
+  "compilerOptions": {
+    // Target and Module
+    "target": "ES2022",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+
+    // Strict Mode (ALL enabled)
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+
+    // Interop
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+
+    // Paths
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
+}
+```
+
+## Common TypeScript Errors
+
+### "Cannot find module"
+
+```
+error TS2307: Cannot find module '@/components/Button'
+```
+
+**Fix**: Ensure paths are configured in both tsconfig.json AND vite.config.ts
+
+### "Object is possibly undefined"
+
+```typescript
+const user = users.find(u => u.id === id);
+console.log(user.name);  // Error: user is possibly undefined
+```
+
+**Fix**: Add null check
+
+```typescript
+if (user) {
+  console.log(user.name);
+}
+```
+
+## Related Tasks
+
+- **T003.1.1**: package.json with TypeScript dependency
+- **T003.1.3**: Tailwind configuration
+- **T003.2**: Main process TypeScript files
+- **T003.3**: Renderer process TypeScript/React files

--- a/log_tests/T003.1.2_Create_tsconfig_TestLog.md
+++ b/log_tests/T003.1.2_Create_tsconfig_TestLog.md
@@ -1,0 +1,97 @@
+# Test Log: T003.1.2 - Create desktop-app/tsconfig.json with strict mode
+
+## Test Information
+- **Task ID**: T003.1.2
+- **Test File**: `tests/desktop_app/test_T003_1_2_tsconfig.py`
+- **Date**: 2025-12-16
+- **Framework**: pytest 9.0.2
+- **Status**: ✅ All Tests Passed
+
+## Test Results Summary
+
+| Test Name | Status | Duration |
+|-----------|--------|----------|
+| test_tsconfig_exists | ✅ PASSED | <0.01s |
+| test_tsconfig_is_valid_json | ✅ PASSED | <0.01s |
+| test_tsconfig_has_compiler_options | ✅ PASSED | <0.01s |
+| test_tsconfig_strict_mode_enabled | ✅ PASSED | <0.01s |
+| test_tsconfig_target_es2022 | ✅ PASSED | <0.01s |
+| test_tsconfig_module_commonjs_or_esnext | ✅ PASSED | <0.01s |
+| test_tsconfig_jsx_react | ✅ PASSED | <0.01s |
+| test_tsconfig_es_module_interop | ✅ PASSED | <0.01s |
+| test_tsconfig_skip_lib_check | ✅ PASSED | <0.01s |
+| test_tsconfig_resolve_json_module | ✅ PASSED | <0.01s |
+| test_tsconfig_has_include | ✅ PASSED | <0.01s |
+
+**Total**: 11 passed in 0.04s
+
+## TDD Workflow
+
+### Red Phase (Tests Fail)
+Initial test run before creating tsconfig.json:
+```
+FAILED test_tsconfig_exists - File not found
+FAILED test_tsconfig_strict_mode_enabled - FileNotFoundError
+... (11 failures total)
+========================= 11 failed in 0.18s ==========================
+```
+
+### Green Phase (Tests Pass)
+After creating tsconfig.json with strict mode:
+```
+tests/desktop_app/test_T003_1_2_tsconfig.py::TestTsConfig::test_tsconfig_exists PASSED [  9%]
+tests/desktop_app/test_T003_1_2_tsconfig.py::TestTsConfig::test_tsconfig_strict_mode_enabled PASSED [ 36%]
+...
+============================== 11 passed in 0.04s ===============================
+```
+
+## Test Cases Description
+
+### test_tsconfig_exists
+**Purpose**: Verify tsconfig.json exists in desktop-app directory
+**Assertion**: `os.path.isfile(TSCONFIG_PATH)` returns True
+
+### test_tsconfig_is_valid_json
+**Purpose**: Verify tsconfig.json is valid JSON
+**Assertion**: `json.loads(content)` completes without error
+
+### test_tsconfig_has_compiler_options
+**Purpose**: Verify compilerOptions section exists
+**Assertion**: "compilerOptions" in data
+
+### test_tsconfig_strict_mode_enabled
+**Purpose**: Verify strict mode is enabled
+**Assertion**: `compilerOptions.strict === true`
+
+### test_tsconfig_target_es2022
+**Purpose**: Verify target is ES2022 or later
+**Assertion**: target in ["ES2022", "ES2023", "ESNEXT"]
+
+### test_tsconfig_module_commonjs_or_esnext
+**Purpose**: Verify module is CommonJS or ESNext
+**Assertion**: module in ["COMMONJS", "ESNEXT", "NODENEXT"]
+
+### test_tsconfig_jsx_react
+**Purpose**: Verify JSX is configured for React
+**Assertion**: jsx in ["react", "react-jsx", "react-jsxdev"]
+
+### test_tsconfig_es_module_interop
+**Purpose**: Verify esModuleInterop is enabled
+**Assertion**: `compilerOptions.esModuleInterop === true`
+
+### test_tsconfig_skip_lib_check
+**Purpose**: Verify skipLibCheck is enabled for faster builds
+**Assertion**: `compilerOptions.skipLibCheck === true`
+
+### test_tsconfig_resolve_json_module
+**Purpose**: Verify resolveJsonModule is enabled
+**Assertion**: `compilerOptions.resolveJsonModule === true`
+
+### test_tsconfig_has_include
+**Purpose**: Verify include section exists and is not empty
+**Assertion**: "include" in data and len > 0
+
+## Test Command
+```bash
+python -m pytest tests/desktop_app/test_T003_1_2_tsconfig.py -v
+```

--- a/specs/001-windows-native-ai/tasks.md
+++ b/specs/001-windows-native-ai/tasks.md
@@ -175,7 +175,13 @@
     - Includes: Scripts (start, dev, build, package, test, lint), electron-builder config
     - Test: `tests/desktop_app/test_T003_1_1_package_json.py` (12 tests passed)
     - Logs: `log_files/T003.1.1_*`, `log_tests/T003.1.1_*`, `log_learn/T003.1.1_*`
-  - [ ] T003.1.2 Create `desktop-app/tsconfig.json` with strict mode
+  - [x] T003.1.2 Create `desktop-app/tsconfig.json` with strict mode ✅ *Completed 2025-12-16*
+    - Created: `desktop-app/tsconfig.json` with full strict mode configuration
+    - Target: ES2022, Module: ESNext, JSX: react-jsx
+    - Strict options: strict, noImplicitAny, strictNullChecks, noUnusedLocals, etc.
+    - Path aliases: @/*, @main/*, @renderer/*
+    - Test: `tests/desktop_app/test_T003_1_2_tsconfig.py` (11 tests passed)
+    - Logs: `log_files/T003.1.2_*`, `log_tests/T003.1.2_*`, `log_learn/T003.1.2_*`
   - [ ] T003.1.3 Create `desktop-app/tailwind.config.js`
   - [ ] T003.1.4 Create `desktop-app/electron-builder.json` for packaging
 

--- a/tests/desktop_app/test_T003_1_2_tsconfig.py
+++ b/tests/desktop_app/test_T003_1_2_tsconfig.py
@@ -1,0 +1,123 @@
+"""
+Test Suite: T003.1.2 - Create desktop-app/tsconfig.json with strict mode
+Tests verify that tsconfig.json exists and has proper TypeScript configuration.
+"""
+
+import os
+import json
+import pytest
+
+# Path to tsconfig.json
+TSCONFIG_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "desktop-app",
+    "tsconfig.json",
+)
+
+
+class TestTsConfig:
+    """Test suite for desktop-app/tsconfig.json."""
+
+    def test_tsconfig_exists(self):
+        """Test that tsconfig.json file exists in desktop-app directory."""
+        assert os.path.isfile(TSCONFIG_PATH), (
+            f"tsconfig.json not found at {TSCONFIG_PATH}"
+        )
+
+    def test_tsconfig_is_valid_json(self):
+        """Test that tsconfig.json is valid JSON."""
+        with open(TSCONFIG_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        # This will raise JSONDecodeError if invalid
+        json.loads(content)
+
+    def test_tsconfig_has_compiler_options(self):
+        """Test that tsconfig.json has compilerOptions section."""
+        with open(TSCONFIG_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        assert "compilerOptions" in data, (
+            "tsconfig.json must have 'compilerOptions' section"
+        )
+
+    def test_tsconfig_strict_mode_enabled(self):
+        """Test that strict mode is enabled."""
+        with open(TSCONFIG_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        compiler_opts = data.get("compilerOptions", {})
+        assert compiler_opts.get("strict") is True, (
+            "tsconfig.json must have 'strict: true'"
+        )
+
+    def test_tsconfig_target_es2022(self):
+        """Test that target is ES2022 or later."""
+        with open(TSCONFIG_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        compiler_opts = data.get("compilerOptions", {})
+        target = compiler_opts.get("target", "").upper()
+        valid_targets = ["ES2022", "ES2023", "ESNEXT"]
+        assert target in valid_targets, (
+            f"tsconfig.json target should be ES2022 or later, got {target}"
+        )
+
+    def test_tsconfig_module_commonjs_or_esnext(self):
+        """Test that module is CommonJS or ESNext."""
+        with open(TSCONFIG_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        compiler_opts = data.get("compilerOptions", {})
+        module = compiler_opts.get("module", "").upper()
+        # For Electron, CommonJS or ESNext are valid
+        valid_modules = ["COMMONJS", "ESNEXT", "NODENEXT"]
+        assert module in valid_modules, (
+            f"tsconfig.json module should be CommonJS or ESNext, got {module}"
+        )
+
+    def test_tsconfig_jsx_react(self):
+        """Test that JSX is configured for React."""
+        with open(TSCONFIG_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        compiler_opts = data.get("compilerOptions", {})
+        jsx = compiler_opts.get("jsx", "").lower()
+        valid_jsx = ["react", "react-jsx", "react-jsxdev"]
+        assert jsx in valid_jsx, (
+            f"tsconfig.json jsx should be 'react' or 'react-jsx', got {jsx}"
+        )
+
+    def test_tsconfig_es_module_interop(self):
+        """Test that esModuleInterop is enabled."""
+        with open(TSCONFIG_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        compiler_opts = data.get("compilerOptions", {})
+        assert compiler_opts.get("esModuleInterop") is True, (
+            "tsconfig.json must have 'esModuleInterop: true'"
+        )
+
+    def test_tsconfig_skip_lib_check(self):
+        """Test that skipLibCheck is enabled for faster builds."""
+        with open(TSCONFIG_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        compiler_opts = data.get("compilerOptions", {})
+        assert compiler_opts.get("skipLibCheck") is True, (
+            "tsconfig.json should have 'skipLibCheck: true'"
+        )
+
+    def test_tsconfig_resolve_json_module(self):
+        """Test that resolveJsonModule is enabled."""
+        with open(TSCONFIG_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        compiler_opts = data.get("compilerOptions", {})
+        assert compiler_opts.get("resolveJsonModule") is True, (
+            "tsconfig.json should have 'resolveJsonModule: true'"
+        )
+
+    def test_tsconfig_has_include(self):
+        """Test that tsconfig.json has include section."""
+        with open(TSCONFIG_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        assert "include" in data, (
+            "tsconfig.json must have 'include' section"
+        )
+        assert len(data["include"]) > 0, (
+            "include section should not be empty"
+        )


### PR DESCRIPTION
- Add tsconfig.json with full TypeScript strict mode configuration
- Configure target ES2022, module ESNext, jsx react-jsx
- Enable all strict type checking options
- Add path aliases (@/*, @main/*, @renderer/*)
- Configure for Vite bundler (moduleResolution: bundler)
- All 11 tests passing