### PR TITLE
feat(T003.2.1): create desktop-app/src/main/index.ts entry point

### DIFF
--- a/desktop-app/src/main/index.ts
+++ b/desktop-app/src/main/index.ts
@@ -1,0 +1,105 @@
+/**
+ * ContPAQ Win - Electron Main Process Entry Point
+ *
+ * This is the main entry point for the Electron application.
+ * It creates and manages the browser window, handles lifecycle events,
+ * and sets up secure communication with the renderer process.
+ */
+
+import { app, BrowserWindow, ipcMain } from 'electron';
+import * as path from 'path';
+
+// Keep a global reference of the window object to prevent garbage collection
+let mainWindow: BrowserWindow | null = null;
+
+// Determine if we're in development mode
+const isDev = process.env.NODE_ENV === 'development';
+
+/**
+ * Creates the main application window with secure defaults.
+ * Configures webPreferences for security best practices.
+ */
+function createWindow(): void {
+  mainWindow = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    minWidth: 800,
+    minHeight: 600,
+    title: 'ContPAQ Win',
+    show: false, // Don't show until ready-to-show
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: true,
+      webSecurity: true,
+      allowRunningInsecureContent: false,
+    },
+  });
+
+  // Show window when ready to prevent visual flash
+  mainWindow.once('ready-to-show', () => {
+    mainWindow?.show();
+  });
+
+  // Load the app
+  if (isDev) {
+    // In development, load from Vite dev server
+    mainWindow.loadURL('http://localhost:5173');
+    // Open DevTools in development
+    mainWindow.webContents.openDevTools();
+  } else {
+    // In production, load the built files
+    mainWindow.loadFile(path.join(__dirname, '../renderer/index.html'));
+  }
+
+  // Handle window closed
+  mainWindow.on('closed', () => {
+    mainWindow = null;
+  });
+}
+
+/**
+ * Application lifecycle event handlers
+ */
+
+// This method will be called when Electron has finished initialization
+app.whenReady().then(() => {
+  createWindow();
+
+  // On macOS, re-create window when dock icon is clicked and no windows are open
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
+    }
+  });
+});
+
+// Quit when all windows are closed (except on macOS)
+app.on('window-all-closed', () => {
+  // On macOS, applications stay active until user quits explicitly with Cmd + Q
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+// Security: Prevent navigation to external URLs
+app.on('web-contents-created', (_event, contents) => {
+  contents.on('will-navigate', (event, navigationUrl) => {
+    const parsedUrl = new URL(navigationUrl);
+    // Only allow navigation to localhost in development
+    if (isDev && parsedUrl.origin === 'http://localhost:5173') {
+      return;
+    }
+    // Block all other navigations
+    event.preventDefault();
+  });
+
+  // Prevent new windows from being created
+  contents.setWindowOpenHandler(() => {
+    return { action: 'deny' };
+  });
+});
+
+// Export for testing purposes
+export { createWindow, mainWindow };

--- a/log_files/T003.2.1_Create_main_index_ts_Log.md
+++ b/log_files/T003.2.1_Create_main_index_ts_Log.md
@@ -1,0 +1,103 @@
+# Implementation Log: T003.2.1 - Create desktop-app/src/main/index.ts
+
+## Task Information
+- **Task ID**: T003.2.1
+- **Task Name**: Create `desktop-app/src/main/index.ts` entry point
+- **Parent Task**: T003.2 - Create Electron main process structure
+- **Date**: 2025-12-16
+- **Status**: ✅ Completed
+
+## Implementation Details
+
+### Objective
+Create the main process entry point for the Electron application with proper security configuration and lifecycle management.
+
+### File Created
+
+**Location**: `desktop-app/src/main/index.ts`
+
+### Core Components
+
+#### 1. Imports
+```typescript
+import { app, BrowserWindow, ipcMain } from 'electron';
+import * as path from 'path';
+```
+
+#### 2. Window Configuration
+
+| Property | Value | Purpose |
+|----------|-------|---------|
+| width | 1200 | Default window width |
+| height | 800 | Default window height |
+| minWidth | 800 | Minimum resize width |
+| minHeight | 600 | Minimum resize height |
+| show | false | Prevents flash on load |
+
+#### 3. Security Configuration (webPreferences)
+
+| Setting | Value | Purpose |
+|---------|-------|---------|
+| nodeIntegration | false | Prevents Node.js access in renderer |
+| contextIsolation | true | Isolates preload from renderer |
+| sandbox | true | Additional process isolation |
+| webSecurity | true | Enforces same-origin policy |
+| allowRunningInsecureContent | false | Blocks mixed content |
+
+#### 4. Lifecycle Handlers
+
+| Event | Handler |
+|-------|---------|
+| `app.whenReady()` | Creates initial window |
+| `activate` | Re-creates window on macOS dock click |
+| `window-all-closed` | Quits app on non-macOS platforms |
+| `web-contents-created` | Security: blocks external navigation |
+
+### Development vs Production
+
+```typescript
+const isDev = process.env.NODE_ENV === 'development';
+
+if (isDev) {
+  mainWindow.loadURL('http://localhost:5173'); // Vite dev server
+  mainWindow.webContents.openDevTools();
+} else {
+  mainWindow.loadFile(path.join(__dirname, '../renderer/index.html'));
+}
+```
+
+### Security Features
+
+1. **Preload Script**: All IPC communication goes through preload
+2. **Context Isolation**: Renderer has no access to Node.js
+3. **Sandbox Mode**: Chromium sandbox enabled
+4. **Navigation Blocking**: Prevents navigating to external URLs
+5. **New Window Prevention**: Blocks popup windows
+
+### Design Decisions
+
+1. **show: false + ready-to-show**: Prevents white flash during load
+
+2. **Global mainWindow reference**: Prevents garbage collection while window is needed
+
+3. **Platform-specific quit behavior**: macOS apps traditionally stay active
+
+4. **Strict security defaults**: Following Electron security best practices
+
+5. **Vite dev server integration**: Hot reload during development on port 5173
+
+### Verification
+- All 13 tests passed successfully
+- Proper Electron imports
+- Secure webPreferences
+- All lifecycle events handled
+
+## Related Files
+- Test file: `tests/desktop_app/test_T003_2_1_main_index.py`
+- Test log: `log_tests/T003.2.1_Create_main_index_ts_TestLog.md`
+- Learn guide: `log_learn/T003.2.1_Create_main_index_ts_Guide.md`
+
+## Next Steps
+- T003.2.2: Create `desktop-app/src/main/preload.ts` with context bridge
+- T003.2.3: Create `desktop-app/src/main/process-manager.ts` stub
+- T003.2.4: Create `desktop-app/src/main/ipc-handlers.ts` stub

--- a/log_learn/T003.2.1_Create_main_index_ts_Guide.md
+++ b/log_learn/T003.2.1_Create_main_index_ts_Guide.md
@@ -1,0 +1,269 @@
+# Learning Guide: T003.2.1 - Electron Main Process
+
+## Overview
+
+Electron applications have two types of processes:
+1. **Main Process**: Node.js environment, controls app lifecycle, creates windows
+2. **Renderer Process**: Chromium environment, runs the web UI
+
+This guide covers the main process entry point (`index.ts`).
+
+## Key Concepts
+
+### Process Architecture
+
+```
+┌─────────────────────────────────────────────┐
+│              Main Process                    │
+│  (Node.js - full system access)             │
+│                                              │
+│  ┌─────────────┐  ┌─────────────┐           │
+│  │ BrowserWindow│  │ BrowserWindow│         │
+│  │  (Renderer) │  │  (Renderer) │          │
+│  │   Chromium  │  │   Chromium  │          │
+│  └─────────────┘  └─────────────┘           │
+│                                              │
+│  ┌─────────────────────────────────┐        │
+│  │     IPC (Inter-Process Comm)     │       │
+│  └─────────────────────────────────┘        │
+└─────────────────────────────────────────────┘
+```
+
+### Core Electron Modules
+
+```typescript
+import { app, BrowserWindow, ipcMain } from 'electron';
+```
+
+| Module | Purpose |
+|--------|---------|
+| `app` | Application lifecycle control |
+| `BrowserWindow` | Creates and manages windows |
+| `ipcMain` | Main-side IPC communication |
+| `Menu` | Application menus |
+| `dialog` | Native dialogs (file picker, etc.) |
+| `shell` | External application launching |
+
+## Application Lifecycle
+
+### Event Order
+
+```
+1. app.on('will-finish-launching')
+2. app.whenReady() / app.on('ready')
+3. [Window created]
+4. app.on('activate') - macOS only
+5. app.on('window-all-closed')
+6. app.on('before-quit')
+7. app.on('will-quit')
+8. app.on('quit')
+```
+
+### Essential Events
+
+```typescript
+// Application is ready - create windows here
+app.whenReady().then(() => {
+  createWindow();
+});
+
+// All windows closed
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+// macOS dock icon clicked
+app.on('activate', () => {
+  if (BrowserWindow.getAllWindows().length === 0) {
+    createWindow();
+  }
+});
+```
+
+## BrowserWindow Configuration
+
+### Basic Configuration
+
+```typescript
+const mainWindow = new BrowserWindow({
+  width: 1200,
+  height: 800,
+  minWidth: 800,
+  minHeight: 600,
+  title: 'My App',
+  icon: path.join(__dirname, 'icon.png'),
+});
+```
+
+### Window Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| width/height | number | Initial size |
+| minWidth/minHeight | number | Minimum resize |
+| x/y | number | Position |
+| center | boolean | Center on screen |
+| resizable | boolean | Allow resize |
+| movable | boolean | Allow move |
+| frame | boolean | Show window frame |
+| transparent | boolean | Transparent background |
+| show | boolean | Show on creation |
+
+## Security: webPreferences
+
+### Secure Defaults
+
+```typescript
+webPreferences: {
+  preload: path.join(__dirname, 'preload.js'),
+  nodeIntegration: false,      // CRITICAL: Disable Node in renderer
+  contextIsolation: true,      // CRITICAL: Isolate contexts
+  sandbox: true,               // Enable Chromium sandbox
+  webSecurity: true,           // Enforce same-origin
+  allowRunningInsecureContent: false,
+}
+```
+
+### Why These Settings Matter
+
+| Setting | Risk if Disabled |
+|---------|------------------|
+| nodeIntegration: false | XSS could run system commands |
+| contextIsolation: true | Malicious code could access preload |
+| sandbox: true | Renderer could access filesystem |
+| webSecurity: true | Cross-origin requests unrestricted |
+
+### Preload Scripts
+
+Preload scripts run in isolated context with limited Node.js access:
+
+```typescript
+// preload.ts
+import { contextBridge, ipcRenderer } from 'electron';
+
+contextBridge.exposeInMainWorld('api', {
+  sendMessage: (msg: string) => ipcRenderer.send('message', msg),
+  onReply: (callback: Function) => ipcRenderer.on('reply', callback),
+});
+```
+
+## Development vs Production
+
+```typescript
+const isDev = process.env.NODE_ENV === 'development';
+
+if (isDev) {
+  // Load from dev server (hot reload)
+  mainWindow.loadURL('http://localhost:5173');
+  mainWindow.webContents.openDevTools();
+} else {
+  // Load bundled files
+  mainWindow.loadFile(path.join(__dirname, '../renderer/index.html'));
+}
+```
+
+### Environment Detection Methods
+
+```typescript
+// Using electron-is-dev package
+import isDev from 'electron-is-dev';
+
+// Manual check
+const isDev = !app.isPackaged;
+
+// Environment variable
+const isDev = process.env.NODE_ENV === 'development';
+```
+
+## Preventing Window Flash
+
+```typescript
+const mainWindow = new BrowserWindow({
+  show: false, // Don't show initially
+  // ...
+});
+
+mainWindow.once('ready-to-show', () => {
+  mainWindow.show(); // Show when content is ready
+});
+```
+
+## Security: Preventing Navigation
+
+```typescript
+app.on('web-contents-created', (_event, contents) => {
+  // Block navigation to external URLs
+  contents.on('will-navigate', (event, url) => {
+    const parsedUrl = new URL(url);
+    if (parsedUrl.origin !== 'http://localhost:5173') {
+      event.preventDefault();
+    }
+  });
+
+  // Block new windows
+  contents.setWindowOpenHandler(() => {
+    return { action: 'deny' };
+  });
+});
+```
+
+## Common Patterns
+
+### Single Window Reference
+
+```typescript
+let mainWindow: BrowserWindow | null = null;
+
+function createWindow() {
+  mainWindow = new BrowserWindow({ ... });
+
+  mainWindow.on('closed', () => {
+    mainWindow = null; // Clear reference
+  });
+}
+```
+
+### Graceful Shutdown
+
+```typescript
+app.on('before-quit', () => {
+  // Cleanup: close database connections, save state
+});
+
+app.on('will-quit', (event) => {
+  // Can prevent quit if needed
+  // event.preventDefault();
+});
+```
+
+### IPC Communication
+
+```typescript
+// Main process
+import { ipcMain } from 'electron';
+
+ipcMain.handle('get-data', async (event, arg) => {
+  return await fetchData(arg);
+});
+
+// Renderer (via preload)
+const data = await window.api.getData('query');
+```
+
+## Best Practices
+
+1. **Always use contextIsolation**: Never disable for security
+2. **Never enable nodeIntegration**: Use preload scripts instead
+3. **Validate all IPC inputs**: Don't trust renderer messages
+4. **Use `show: false`**: Prevents white flash on startup
+5. **Handle all lifecycle events**: Especially window-all-closed
+6. **Clear window references**: Set to null on close
+
+## Resources
+
+- [Electron Security Checklist](https://www.electronjs.org/docs/tutorial/security)
+- [Electron Quick Start](https://www.electronjs.org/docs/tutorial/quick-start)
+- [BrowserWindow API](https://www.electronjs.org/docs/api/browser-window)
+- [app API](https://www.electronjs.org/docs/api/app)

--- a/log_tests/T003.2.1_Create_main_index_ts_TestLog.md
+++ b/log_tests/T003.2.1_Create_main_index_ts_TestLog.md
@@ -1,0 +1,127 @@
+# Test Log: T003.2.1 - Create desktop-app/src/main/index.ts
+
+## Test Information
+- **Task ID**: T003.2.1
+- **Test File**: `tests/desktop_app/test_T003_2_1_main_index.py`
+- **Date**: 2025-12-16
+- **Framework**: pytest 9.0.2
+- **Status**: ✅ All Tests Passed
+
+## Test Results Summary
+
+| Test Name | Status | Duration |
+|-----------|--------|----------|
+| test_main_index_ts_exists | ✅ PASSED | <0.01s |
+| test_main_index_ts_is_not_empty | ✅ PASSED | <0.01s |
+| test_main_index_imports_electron_app | ✅ PASSED | <0.01s |
+| test_main_index_imports_browser_window | ✅ PASSED | <0.01s |
+| test_main_index_has_create_window_function | ✅ PASSED | <0.01s |
+| test_main_index_has_app_ready_handler | ✅ PASSED | <0.01s |
+| test_main_index_has_window_all_closed_handler | ✅ PASSED | <0.01s |
+| test_main_index_has_activate_handler | ✅ PASSED | <0.01s |
+| test_main_index_creates_browser_window_instance | ✅ PASSED | <0.01s |
+| test_main_index_has_webpreferences | ✅ PASSED | <0.01s |
+| test_main_index_has_preload_reference | ✅ PASSED | <0.01s |
+| test_main_index_disables_node_integration | ✅ PASSED | <0.01s |
+| test_main_index_enables_context_isolation | ✅ PASSED | <0.01s |
+
+**Total**: 13 passed in 0.04s
+
+## TDD Workflow
+
+### Red Phase (Tests Fail)
+Initial test run before creating index.ts:
+```
+FAILED test_main_index_ts_exists - AssertionError: index.ts not found
+FAILED test_main_index_ts_is_not_empty - FileNotFoundError
+FAILED test_main_index_imports_electron_app - FileNotFoundError
+FAILED test_main_index_imports_browser_window - FileNotFoundError
+FAILED test_main_index_has_create_window_function - FileNotFoundError
+FAILED test_main_index_has_app_ready_handler - FileNotFoundError
+FAILED test_main_index_has_window_all_closed_handler - FileNotFoundError
+FAILED test_main_index_has_activate_handler - FileNotFoundError
+FAILED test_main_index_creates_browser_window_instance - FileNotFoundError
+FAILED test_main_index_has_webpreferences - FileNotFoundError
+FAILED test_main_index_has_preload_reference - FileNotFoundError
+FAILED test_main_index_disables_node_integration - FileNotFoundError
+FAILED test_main_index_enables_context_isolation - FileNotFoundError
+========================= 13 failed in 0.20s ==========================
+```
+
+### Green Phase (Tests Pass)
+After creating index.ts with all required components:
+```
+tests/desktop_app/test_T003_2_1_main_index.py::TestMainIndexTs::test_main_index_ts_exists PASSED [  7%]
+tests/desktop_app/test_T003_2_1_main_index.py::TestMainIndexTs::test_main_index_ts_is_not_empty PASSED [ 15%]
+tests/desktop_app/test_T003_2_1_main_index.py::TestMainIndexTs::test_main_index_imports_electron_app PASSED [ 23%]
+tests/desktop_app/test_T003_2_1_main_index.py::TestMainIndexTs::test_main_index_imports_browser_window PASSED [ 30%]
+tests/desktop_app/test_T003_2_1_main_index.py::TestMainIndexTs::test_main_index_has_create_window_function PASSED [ 38%]
+tests/desktop_app/test_T003_2_1_main_index.py::TestMainIndexTs::test_main_index_has_app_ready_handler PASSED [ 46%]
+tests/desktop_app/test_T003_2_1_main_index.py::TestMainIndexTs::test_main_index_has_window_all_closed_handler PASSED [ 53%]
+tests/desktop_app/test_T003_2_1_main_index.py::TestMainIndexTs::test_main_index_has_activate_handler PASSED [ 61%]
+tests/desktop_app/test_T003_2_1_main_index.py::TestMainIndexTs::test_main_index_creates_browser_window_instance PASSED [ 69%]
+tests/desktop_app/test_T003_2_1_main_index.py::TestMainIndexTs::test_main_index_has_webpreferences PASSED [ 76%]
+tests/desktop_app/test_T003_2_1_main_index.py::TestMainIndexTs::test_main_index_has_preload_reference PASSED [ 84%]
+tests/desktop_app/test_T003_2_1_main_index.py::TestMainIndexTs::test_main_index_disables_node_integration PASSED [ 92%]
+tests/desktop_app/test_T003_2_1_main_index.py::TestMainIndexTs::test_main_index_enables_context_isolation PASSED [100%]
+============================== 13 passed in 0.04s ===============================
+```
+
+## Test Cases Description
+
+### test_main_index_ts_exists
+**Purpose**: Verify index.ts exists in src/main directory
+**Assertion**: `os.path.isfile(MAIN_INDEX_PATH)` returns True
+
+### test_main_index_ts_is_not_empty
+**Purpose**: Verify file has content (not just created empty)
+**Assertion**: `len(content.strip()) > 0`
+
+### test_main_index_imports_electron_app
+**Purpose**: Verify Electron app module is imported
+**Assertion**: Both "app" and "electron" appear in content
+
+### test_main_index_imports_browser_window
+**Purpose**: Verify BrowserWindow is imported for creating windows
+**Assertion**: "BrowserWindow" appears in content
+
+### test_main_index_has_create_window_function
+**Purpose**: Verify window creation logic exists
+**Assertion**: "createWindow" function pattern found
+
+### test_main_index_has_app_ready_handler
+**Purpose**: Verify app initialization is handled
+**Assertion**: "app.whenReady()" or "app.on('ready'" found
+
+### test_main_index_has_window_all_closed_handler
+**Purpose**: Verify quit behavior is handled
+**Assertion**: "window-all-closed" string found
+
+### test_main_index_has_activate_handler
+**Purpose**: Verify macOS dock click is handled
+**Assertion**: "activate" string found
+
+### test_main_index_creates_browser_window_instance
+**Purpose**: Verify window is actually instantiated
+**Assertion**: "new BrowserWindow" found
+
+### test_main_index_has_webpreferences
+**Purpose**: Verify security configuration exists
+**Assertion**: "webPreferences" found
+
+### test_main_index_has_preload_reference
+**Purpose**: Verify preload script is configured
+**Assertion**: "preload" found in content
+
+### test_main_index_disables_node_integration
+**Purpose**: Verify Node.js is disabled in renderer (security)
+**Assertion**: "nodeIntegration" found
+
+### test_main_index_enables_context_isolation
+**Purpose**: Verify context isolation is enabled (security)
+**Assertion**: "contextIsolation" found
+
+## Test Command
+```bash
+python -m pytest tests/desktop_app/test_T003_2_1_main_index.py -v
+```

--- a/specs/001-windows-native-ai/tasks.md
+++ b/specs/001-windows-native-ai/tasks.md
@@ -199,7 +199,14 @@
     - Logs: `log_files/T003.1.4_*`, `log_tests/T003.1.4_*`, `log_learn/T003.1.4_*`
 
 - [ ] **T003.2** [P] Create Electron main process structure
-  - [ ] T003.2.1 Create `desktop-app/src/main/index.ts` entry point
+  - [x] T003.2.1 Create `desktop-app/src/main/index.ts` entry point ✅ *Completed 2025-12-16*
+    - Created: `desktop-app/src/main/index.ts` with Electron main process entry point
+    - Imports: app, BrowserWindow, ipcMain from electron
+    - Security: nodeIntegration=false, contextIsolation=true, sandbox=true
+    - Lifecycle: app.whenReady(), window-all-closed, activate handlers
+    - Features: Dev/prod mode, navigation blocking, window flash prevention
+    - Test: `tests/desktop_app/test_T003_2_1_main_index.py` (13 tests passed)
+    - Logs: `log_files/T003.2.1_*`, `log_tests/T003.2.1_*`, `log_learn/T003.2.1_*`
   - [ ] T003.2.2 Create `desktop-app/src/main/preload.ts` with context bridge
   - [ ] T003.2.3 Create `desktop-app/src/main/process-manager.ts` stub
   - [ ] T003.2.4 Create `desktop-app/src/main/ipc-handlers.ts` stub

--- a/tests/desktop_app/test_T003_2_1_main_index.py
+++ b/tests/desktop_app/test_T003_2_1_main_index.py
@@ -1,0 +1,137 @@
+"""
+Tests for T003.2.1: Create desktop-app/src/main/index.ts
+
+Tests verify that the Electron main process entry point exists
+and contains all required components for a proper Electron application.
+"""
+
+import os
+import re
+
+import pytest
+
+
+# Path to the main index.ts file
+MAIN_INDEX_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+    "desktop-app",
+    "src",
+    "main",
+    "index.ts",
+)
+
+
+class TestMainIndexTs:
+    """Test suite for desktop-app/src/main/index.ts."""
+
+    def test_main_index_ts_exists(self):
+        """Test that index.ts exists in src/main directory."""
+        assert os.path.isfile(MAIN_INDEX_PATH), (
+            f"index.ts not found at {MAIN_INDEX_PATH}"
+        )
+
+    def test_main_index_ts_is_not_empty(self):
+        """Test that index.ts has content."""
+        with open(MAIN_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        assert len(content.strip()) > 0, "index.ts must not be empty"
+
+    def test_main_index_imports_electron_app(self):
+        """Test that index.ts imports app from electron."""
+        with open(MAIN_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        # Check for import { app, ... } from 'electron' or similar
+        assert "app" in content and "electron" in content, (
+            "index.ts must import app from electron"
+        )
+
+    def test_main_index_imports_browser_window(self):
+        """Test that index.ts imports BrowserWindow from electron."""
+        with open(MAIN_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "BrowserWindow" in content, (
+            "index.ts must import BrowserWindow from electron"
+        )
+
+    def test_main_index_has_create_window_function(self):
+        """Test that index.ts has a createWindow function."""
+        with open(MAIN_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        # Check for function createWindow or const createWindow =
+        has_create_window = (
+            "function createWindow" in content or
+            "createWindow" in content and ("=>" in content or "function" in content)
+        )
+        assert has_create_window, (
+            "index.ts must have a createWindow function"
+        )
+
+    def test_main_index_has_app_ready_handler(self):
+        """Test that index.ts handles app ready event."""
+        with open(MAIN_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        # Check for app.whenReady() or app.on('ready', ...)
+        has_ready_handler = (
+            "app.whenReady()" in content or
+            "app.on('ready'" in content or
+            'app.on("ready"' in content
+        )
+        assert has_ready_handler, (
+            "index.ts must handle app ready event with app.whenReady() or app.on('ready')"
+        )
+
+    def test_main_index_has_window_all_closed_handler(self):
+        """Test that index.ts handles window-all-closed event."""
+        with open(MAIN_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "window-all-closed" in content, (
+            "index.ts must handle window-all-closed event"
+        )
+
+    def test_main_index_has_activate_handler(self):
+        """Test that index.ts handles activate event for macOS."""
+        with open(MAIN_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "activate" in content, (
+            "index.ts must handle activate event for macOS dock click"
+        )
+
+    def test_main_index_creates_browser_window_instance(self):
+        """Test that index.ts creates a new BrowserWindow."""
+        with open(MAIN_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "new BrowserWindow" in content, (
+            "index.ts must create a new BrowserWindow instance"
+        )
+
+    def test_main_index_has_webpreferences(self):
+        """Test that index.ts configures webPreferences for security."""
+        with open(MAIN_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "webPreferences" in content, (
+            "index.ts must configure webPreferences for BrowserWindow"
+        )
+
+    def test_main_index_has_preload_reference(self):
+        """Test that index.ts references preload script."""
+        with open(MAIN_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "preload" in content, (
+            "index.ts must reference preload script in webPreferences"
+        )
+
+    def test_main_index_disables_node_integration(self):
+        """Test that index.ts disables nodeIntegration for security."""
+        with open(MAIN_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "nodeIntegration" in content, (
+            "index.ts must explicitly set nodeIntegration"
+        )
+
+    def test_main_index_enables_context_isolation(self):
+        """Test that index.ts enables contextIsolation for security."""
+        with open(MAIN_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "contextIsolation" in content, (
+            "index.ts must enable contextIsolation for security"
+        )


### PR DESCRIPTION
Add Electron main process entry point with:
- BrowserWindow creation with secure webPreferences
- Security: nodeIntegration=false, contextIsolation=true, sandbox=true
- Lifecycle handlers: app.whenReady(), window-all-closed, activate
- Navigation blocking to prevent external URL access
- Development mode with Vite dev server (port 5173)
- Production mode with bundled files
- Window flash prevention with show:false + ready-to-show

TDD: 13 tests passed