### PR TITLE
feat(T003.2.4): create desktop-app/src/main/ipc-handlers.ts stub

### DIFF
--- a/desktop-app/src/main/ipc-handlers.ts
+++ b/desktop-app/src/main/ipc-handlers.ts
@@ -1,0 +1,317 @@
+/**
+ * ContPAQ Win - IPC Handlers
+ *
+ * Registers all IPC handlers for communication between
+ * the renderer process and main process.
+ *
+ * This is a stub implementation that will be completed as
+ * features are implemented.
+ */
+
+import { ipcMain, dialog, app, BrowserWindow } from 'electron';
+import { processManager } from './process-manager';
+
+/**
+ * AI Service IPC Handlers
+ * Handles communication with the Python AI service
+ */
+function registerAIServiceHandlers(): void {
+  // Extract invoice data from PDF
+  ipcMain.handle('ai:extract-invoice', async (_event, filePath: string) => {
+    // TODO: Implement actual AI service call
+    console.log('Stub: ai:extract-invoice', filePath);
+    return {
+      success: false,
+      error: 'Not implemented',
+      message: 'AI extraction not yet implemented',
+    };
+  });
+
+  // Check AI service health
+  ipcMain.handle('ai:check-health', async () => {
+    const health = await processManager.checkHealth('ai');
+    return health;
+  });
+
+  // Get AI service status
+  ipcMain.handle('ai:get-status', async () => {
+    return {
+      status: processManager.getAIServiceStatus(),
+      running: processManager.isAIServiceRunning(),
+    };
+  });
+}
+
+/**
+ * Windows Bridge IPC Handlers
+ * Handles communication with the .NET Windows Bridge service
+ */
+function registerBridgeServiceHandlers(): void {
+  // Check Bridge service health
+  ipcMain.handle('bridge:check-health', async () => {
+    const health = await processManager.checkHealth('bridge');
+    return health;
+  });
+
+  // Get vendors from ContPAQi
+  ipcMain.handle('bridge:get-vendors', async (_event, searchQuery?: string) => {
+    // TODO: Implement actual Bridge service call
+    console.log('Stub: bridge:get-vendors', searchQuery);
+    return {
+      success: false,
+      error: 'Not implemented',
+      vendors: [],
+    };
+  });
+
+  // Get vendor by RFC
+  ipcMain.handle('bridge:get-vendor-by-rfc', async (_event, rfc: string) => {
+    // TODO: Implement actual Bridge service call
+    console.log('Stub: bridge:get-vendor-by-rfc', rfc);
+    return {
+      success: false,
+      error: 'Not implemented',
+      vendor: null,
+    };
+  });
+
+  // Create vendor in ContPAQi
+  ipcMain.handle('bridge:create-vendor', async (_event, vendorData: unknown) => {
+    // TODO: Implement actual Bridge service call
+    console.log('Stub: bridge:create-vendor', vendorData);
+    return {
+      success: false,
+      error: 'Not implemented',
+    };
+  });
+
+  // Check for duplicate entry
+  ipcMain.handle('bridge:check-duplicate', async (_event, invoiceData: unknown) => {
+    // TODO: Implement actual Bridge service call
+    console.log('Stub: bridge:check-duplicate', invoiceData);
+    return {
+      success: false,
+      error: 'Not implemented',
+      isDuplicate: false,
+    };
+  });
+
+  // Create entry in ContPAQi
+  ipcMain.handle('bridge:create-entry', async (_event, entryData: unknown) => {
+    // TODO: Implement actual Bridge service call
+    console.log('Stub: bridge:create-entry', entryData);
+    return {
+      success: false,
+      error: 'Not implemented',
+      folio: null,
+    };
+  });
+}
+
+/**
+ * Database IPC Handlers
+ * Handles local SQLite database operations
+ */
+function registerDatabaseHandlers(): void {
+  // Get all invoices with optional filtering
+  ipcMain.handle('db:get-invoices', async (_event, filters?: unknown) => {
+    // TODO: Implement database query
+    console.log('Stub: db:get-invoices', filters);
+    return {
+      success: false,
+      error: 'Not implemented',
+      invoices: [],
+    };
+  });
+
+  // Get single invoice by ID
+  ipcMain.handle('db:get-invoice', async (_event, invoiceId: string) => {
+    // TODO: Implement database query
+    console.log('Stub: db:get-invoice', invoiceId);
+    return {
+      success: false,
+      error: 'Not implemented',
+      invoice: null,
+    };
+  });
+
+  // Save new invoice
+  ipcMain.handle('db:save-invoice', async (_event, invoiceData: unknown) => {
+    // TODO: Implement database insert
+    console.log('Stub: db:save-invoice', invoiceData);
+    return {
+      success: false,
+      error: 'Not implemented',
+      id: null,
+    };
+  });
+
+  // Update existing invoice
+  ipcMain.handle('db:update-invoice', async (_event, invoiceId: string, updates: unknown) => {
+    // TODO: Implement database update
+    console.log('Stub: db:update-invoice', invoiceId, updates);
+    return {
+      success: false,
+      error: 'Not implemented',
+    };
+  });
+
+  // Delete invoice
+  ipcMain.handle('db:delete-invoice', async (_event, invoiceId: string) => {
+    // TODO: Implement database delete
+    console.log('Stub: db:delete-invoice', invoiceId);
+    return {
+      success: false,
+      error: 'Not implemented',
+    };
+  });
+}
+
+/**
+ * App IPC Handlers
+ * Handles general application operations
+ */
+function registerAppHandlers(): void {
+  // Get application version
+  ipcMain.handle('app:get-version', async () => {
+    return app.getVersion();
+  });
+
+  // Get application configuration
+  ipcMain.handle('app:get-config', async () => {
+    return {
+      version: app.getVersion(),
+      platform: process.platform,
+      arch: process.arch,
+      userDataPath: app.getPath('userData'),
+      isPackaged: app.isPackaged,
+    };
+  });
+
+  // Open file dialog for PDF selection
+  ipcMain.handle('app:open-file-dialog', async () => {
+    const window = BrowserWindow.getFocusedWindow();
+    if (!window) {
+      return { canceled: true, filePaths: [] };
+    }
+
+    const result = await dialog.showOpenDialog(window, {
+      title: 'Seleccionar Factura PDF',
+      filters: [
+        { name: 'PDF Files', extensions: ['pdf'] },
+        { name: 'All Files', extensions: ['*'] },
+      ],
+      properties: ['openFile', 'multiSelections'],
+    });
+
+    return result;
+  });
+
+  // Save file dialog
+  ipcMain.handle('app:save-file-dialog', async (_event, defaultName: string) => {
+    const window = BrowserWindow.getFocusedWindow();
+    if (!window) {
+      return { canceled: true, filePath: undefined };
+    }
+
+    const result = await dialog.showSaveDialog(window, {
+      title: 'Guardar Archivo',
+      defaultPath: defaultName,
+      filters: [
+        { name: 'All Files', extensions: ['*'] },
+      ],
+    });
+
+    return result;
+  });
+}
+
+/**
+ * Window IPC Handlers
+ * Handles window control operations
+ */
+function registerWindowHandlers(): void {
+  // Minimize window
+  ipcMain.on('window:minimize', () => {
+    const window = BrowserWindow.getFocusedWindow();
+    window?.minimize();
+  });
+
+  // Maximize/restore window
+  ipcMain.on('window:maximize', () => {
+    const window = BrowserWindow.getFocusedWindow();
+    if (window?.isMaximized()) {
+      window.restore();
+    } else {
+      window?.maximize();
+    }
+  });
+
+  // Close window
+  ipcMain.on('window:close', () => {
+    const window = BrowserWindow.getFocusedWindow();
+    window?.close();
+  });
+}
+
+/**
+ * Register all IPC handlers
+ * Call this function during app initialization
+ */
+export function registerHandlers(): void {
+  console.log('Registering IPC handlers...');
+
+  registerAIServiceHandlers();
+  registerBridgeServiceHandlers();
+  registerDatabaseHandlers();
+  registerAppHandlers();
+  registerWindowHandlers();
+
+  console.log('IPC handlers registered');
+}
+
+/**
+ * Unregister all IPC handlers
+ * Call this function during app shutdown if needed
+ */
+export function unregisterHandlers(): void {
+  // Remove AI service handlers
+  ipcMain.removeHandler('ai:extract-invoice');
+  ipcMain.removeHandler('ai:check-health');
+  ipcMain.removeHandler('ai:get-status');
+
+  // Remove Bridge service handlers
+  ipcMain.removeHandler('bridge:check-health');
+  ipcMain.removeHandler('bridge:get-vendors');
+  ipcMain.removeHandler('bridge:get-vendor-by-rfc');
+  ipcMain.removeHandler('bridge:create-vendor');
+  ipcMain.removeHandler('bridge:check-duplicate');
+  ipcMain.removeHandler('bridge:create-entry');
+
+  // Remove Database handlers
+  ipcMain.removeHandler('db:get-invoices');
+  ipcMain.removeHandler('db:get-invoice');
+  ipcMain.removeHandler('db:save-invoice');
+  ipcMain.removeHandler('db:update-invoice');
+  ipcMain.removeHandler('db:delete-invoice');
+
+  // Remove App handlers
+  ipcMain.removeHandler('app:get-version');
+  ipcMain.removeHandler('app:get-config');
+  ipcMain.removeHandler('app:open-file-dialog');
+  ipcMain.removeHandler('app:save-file-dialog');
+
+  // Note: ipcMain.on listeners (window handlers) would need
+  // to be removed with removeListener if references were kept
+
+  console.log('IPC handlers unregistered');
+}
+
+// Export individual registration functions for testing
+export {
+  registerAIServiceHandlers,
+  registerBridgeServiceHandlers,
+  registerDatabaseHandlers,
+  registerAppHandlers,
+  registerWindowHandlers,
+};

--- a/log_files/T003.2.4_Create_ipc_handlers_ts_Log.md
+++ b/log_files/T003.2.4_Create_ipc_handlers_ts_Log.md
@@ -1,0 +1,128 @@
+# Implementation Log: T003.2.4 - Create desktop-app/src/main/ipc-handlers.ts
+
+## Task Information
+- **Task ID**: T003.2.4
+- **Task Name**: Create `desktop-app/src/main/ipc-handlers.ts` stub
+- **Parent Task**: T003.2 - Create Electron main process structure
+- **Date**: 2025-12-16
+- **Status**: ✅ Completed
+
+## Implementation Details
+
+### Objective
+Create a stub implementation for IPC handlers that will process messages from the renderer process via the preload script.
+
+### File Created
+
+**Location**: `desktop-app/src/main/ipc-handlers.ts`
+
+### Core Components
+
+#### Handler Categories
+
+| Category | Function | Channels |
+|----------|----------|----------|
+| AI Service | registerAIServiceHandlers() | ai:extract-invoice, ai:check-health, ai:get-status |
+| Bridge Service | registerBridgeServiceHandlers() | bridge:check-health, bridge:get-vendors, etc. |
+| Database | registerDatabaseHandlers() | db:get-invoices, db:save-invoice, etc. |
+| App | registerAppHandlers() | app:get-version, app:open-file-dialog, etc. |
+| Window | registerWindowHandlers() | window:minimize, window:maximize, window:close |
+
+#### Registered Channels
+
+**AI Service (invoke):**
+- `ai:extract-invoice` - Extract data from PDF
+- `ai:check-health` - Check AI service health
+- `ai:get-status` - Get AI service status
+
+**Bridge Service (invoke):**
+- `bridge:check-health` - Check Bridge health
+- `bridge:get-vendors` - Get vendors from ContPAQi
+- `bridge:get-vendor-by-rfc` - Get vendor by RFC
+- `bridge:create-vendor` - Create vendor in ContPAQi
+- `bridge:check-duplicate` - Check for duplicate entries
+- `bridge:create-entry` - Create entry in ContPAQi
+
+**Database (invoke):**
+- `db:get-invoices` - Get all invoices with filters
+- `db:get-invoice` - Get single invoice by ID
+- `db:save-invoice` - Save new invoice
+- `db:update-invoice` - Update existing invoice
+- `db:delete-invoice` - Delete invoice
+
+**App (invoke):**
+- `app:get-version` - Get app version
+- `app:get-config` - Get app configuration
+- `app:open-file-dialog` - Open PDF file picker
+- `app:save-file-dialog` - Open save dialog
+
+**Window (on - fire and forget):**
+- `window:minimize` - Minimize window
+- `window:maximize` - Maximize/restore window
+- `window:close` - Close window
+
+### Exports
+
+```typescript
+// Main registration function
+export function registerHandlers(): void
+
+// Cleanup function
+export function unregisterHandlers(): void
+
+// Individual category functions (for testing)
+export {
+  registerAIServiceHandlers,
+  registerBridgeServiceHandlers,
+  registerDatabaseHandlers,
+  registerAppHandlers,
+  registerWindowHandlers,
+}
+```
+
+### Stub Response Pattern
+
+All stub handlers return consistent response objects:
+```typescript
+{
+  success: false,
+  error: 'Not implemented',
+  // ... additional fields as needed
+}
+```
+
+### Design Decisions
+
+1. **Grouped by service**: Handlers organized by the service they communicate with
+
+2. **Async by default**: All invoke handlers are async for real implementation
+
+3. **Spanish UI strings**: File dialogs use Spanish labels (Seleccionar Factura PDF)
+
+4. **Cleanup support**: unregisterHandlers() for proper shutdown
+
+5. **Uses ProcessManager**: Integrates with process-manager.ts for health checks
+
+### Integration Points
+
+- Imports `processManager` from `./process-manager`
+- Imports `dialog`, `app`, `BrowserWindow` from electron
+- Matches channels defined in `preload.ts`
+
+### Verification
+- All 10 tests passed successfully
+- Has ipcMain import
+- Has registerHandlers function
+- Has AI, Bridge, Database handlers
+- Uses async handlers
+
+## Related Files
+- Test file: `tests/desktop_app/test_T003_2_4_ipc_handlers.py`
+- Test log: `log_tests/T003.2.4_Create_ipc_handlers_ts_TestLog.md`
+- Learn guide: `log_learn/T003.2.4_Create_ipc_handlers_ts_Guide.md`
+- Related: `preload.ts` (defines matching channels)
+- Related: `process-manager.ts` (health checks)
+
+## Next Steps
+- T003.3: Create React renderer structure
+- Implement actual handler logic as features are developed

--- a/log_learn/T003.2.4_Create_ipc_handlers_ts_Guide.md
+++ b/log_learn/T003.2.4_Create_ipc_handlers_ts_Guide.md
@@ -1,0 +1,343 @@
+# Learning Guide: T003.2.4 - IPC Handlers in Electron
+
+## Overview
+
+IPC (Inter-Process Communication) handlers in Electron's main process respond to messages from renderer processes. This guide covers patterns for organizing and implementing IPC handlers.
+
+## IPC Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                      Renderer Process                             │
+│  window.api.invoke('ai:extract-invoice', filePath)               │
+│               │                                                   │
+│               ▼                                                   │
+│  ┌─────────────────────────┐                                     │
+│  │     Preload Script      │                                     │
+│  │  ipcRenderer.invoke()   │                                     │
+│  └─────────────────────────┘                                     │
+└──────────────────────────────────────────────────────────────────┘
+                         │ IPC Channel
+                         ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                       Main Process                                │
+│  ┌─────────────────────────┐                                     │
+│  │     IPC Handlers        │                                     │
+│  │  ipcMain.handle(...)    │                                     │
+│  └─────────────────────────┘                                     │
+│               │                                                   │
+│               ▼                                                   │
+│  ┌─────────────────────────┐                                     │
+│  │   Business Logic        │                                     │
+│  │   (Services, DB, etc.)  │                                     │
+│  └─────────────────────────┘                                     │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## Handler Types
+
+### handle() - Request/Response
+
+```typescript
+import { ipcMain } from 'electron';
+
+// Register handler
+ipcMain.handle('channel-name', async (event, arg1, arg2) => {
+  // Process request
+  const result = await doSomething(arg1, arg2);
+  return result; // Returned to renderer
+});
+
+// In renderer (via preload)
+const result = await window.api.invoke('channel-name', arg1, arg2);
+```
+
+### on() - Fire and Forget
+
+```typescript
+// Register listener
+ipcMain.on('channel-name', (event, arg1) => {
+  // Process message (no return value expected)
+  doSomething(arg1);
+});
+
+// In renderer (via preload)
+window.api.send('channel-name', arg1);
+```
+
+### Sending to Renderer
+
+```typescript
+// From main process to renderer
+const mainWindow = BrowserWindow.getFocusedWindow();
+mainWindow.webContents.send('event-name', data);
+
+// In renderer (via preload)
+window.api.on('event-name', (data) => {
+  console.log('Received:', data);
+});
+```
+
+## Organization Patterns
+
+### Pattern 1: Single File (Small Apps)
+
+```typescript
+// ipc-handlers.ts
+import { ipcMain } from 'electron';
+
+export function registerHandlers() {
+  ipcMain.handle('get-data', async () => { ... });
+  ipcMain.handle('save-data', async () => { ... });
+  ipcMain.on('log', () => { ... });
+}
+```
+
+### Pattern 2: Grouped by Feature (Recommended)
+
+```typescript
+// ipc-handlers.ts
+function registerUserHandlers() {
+  ipcMain.handle('user:get', async () => { ... });
+  ipcMain.handle('user:create', async () => { ... });
+}
+
+function registerInvoiceHandlers() {
+  ipcMain.handle('invoice:list', async () => { ... });
+  ipcMain.handle('invoice:save', async () => { ... });
+}
+
+export function registerHandlers() {
+  registerUserHandlers();
+  registerInvoiceHandlers();
+}
+```
+
+### Pattern 3: Separate Files (Large Apps)
+
+```
+src/main/
+├── ipc/
+│   ├── index.ts          # Aggregates all handlers
+│   ├── user.handlers.ts
+│   ├── invoice.handlers.ts
+│   └── app.handlers.ts
+└── index.ts
+```
+
+## Channel Naming Convention
+
+### Recommended: Namespaced Channels
+
+```typescript
+// Format: service:action
+'ai:extract-invoice'
+'db:get-invoices'
+'bridge:create-entry'
+'app:get-version'
+'window:close'
+```
+
+### Benefits
+- Clear ownership of channels
+- Easy to find handlers
+- Prevents naming collisions
+- Matches preload whitelist
+
+## Response Patterns
+
+### Success Response
+
+```typescript
+ipcMain.handle('api:get-data', async () => {
+  try {
+    const data = await fetchData();
+    return {
+      success: true,
+      data: data,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+});
+```
+
+### Typed Responses
+
+```typescript
+interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}
+
+ipcMain.handle('user:get', async (_event, id: string): Promise<ApiResponse<User>> => {
+  try {
+    const user = await userService.get(id);
+    return { success: true, data: user };
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+});
+```
+
+## Error Handling
+
+### Try-Catch in Handlers
+
+```typescript
+ipcMain.handle('risky-operation', async (_event, data) => {
+  try {
+    const result = await riskyOperation(data);
+    return { success: true, result };
+  } catch (error) {
+    console.error('Handler error:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+});
+```
+
+### Global Error Handler
+
+```typescript
+function createSafeHandler<T>(
+  handler: (...args: unknown[]) => Promise<T>
+): (...args: unknown[]) => Promise<{ success: boolean; data?: T; error?: string }> {
+  return async (...args) => {
+    try {
+      const data = await handler(...args);
+      return { success: true, data };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  };
+}
+
+// Usage
+ipcMain.handle('safe-operation', createSafeHandler(async (event, data) => {
+  return await doSomething(data);
+}));
+```
+
+## Cleanup
+
+### Removing Handlers
+
+```typescript
+// Remove specific handler
+ipcMain.removeHandler('channel-name');
+
+// Remove all listeners for a channel
+ipcMain.removeAllListeners('channel-name');
+```
+
+### Unregister Pattern
+
+```typescript
+export function unregisterHandlers() {
+  const channels = [
+    'ai:extract-invoice',
+    'db:get-invoices',
+    // ... all channels
+  ];
+
+  channels.forEach(channel => {
+    ipcMain.removeHandler(channel);
+  });
+}
+```
+
+## Integration with Services
+
+### Service Injection
+
+```typescript
+// ipc-handlers.ts
+import { UserService } from '../services/user.service';
+import { InvoiceService } from '../services/invoice.service';
+
+export function registerHandlers(
+  userService: UserService,
+  invoiceService: InvoiceService
+) {
+  ipcMain.handle('user:get', async (_event, id) => {
+    return userService.get(id);
+  });
+
+  ipcMain.handle('invoice:list', async () => {
+    return invoiceService.list();
+  });
+}
+```
+
+### Singleton Services
+
+```typescript
+import { processManager } from './process-manager';
+import { database } from './database';
+
+ipcMain.handle('ai:check-health', async () => {
+  return processManager.checkHealth('ai');
+});
+
+ipcMain.handle('db:query', async (_event, query) => {
+  return database.query(query);
+});
+```
+
+## Testing IPC Handlers
+
+### Unit Testing
+
+```typescript
+// Mock ipcMain
+jest.mock('electron', () => ({
+  ipcMain: {
+    handle: jest.fn(),
+    on: jest.fn(),
+  },
+}));
+
+test('registers handlers', () => {
+  registerHandlers();
+  expect(ipcMain.handle).toHaveBeenCalledWith('ai:extract-invoice', expect.any(Function));
+});
+```
+
+### Integration Testing
+
+```typescript
+// Use spectron or playwright for E2E testing
+test('invoke returns data', async () => {
+  const result = await electronApp.evaluate(({ ipcMain }) => {
+    // Test IPC communication
+  });
+  expect(result).toBeDefined();
+});
+```
+
+## Best Practices
+
+1. **Always use async handlers** - Even if operation is sync
+2. **Return consistent response objects** - { success, data, error }
+3. **Log errors in handlers** - For debugging
+4. **Use namespaced channels** - For organization
+5. **Match preload whitelist** - Channels must align
+6. **Validate input** - Don't trust renderer data
+7. **Keep handlers thin** - Delegate to services
+8. **Clean up on shutdown** - Remove handlers
+
+## Resources
+
+- [Electron IPC Tutorial](https://www.electronjs.org/docs/tutorial/ipc)
+- [ipcMain API](https://www.electronjs.org/docs/api/ipc-main)
+- [ipcRenderer API](https://www.electronjs.org/docs/api/ipc-renderer)

--- a/log_tests/T003.2.4_Create_ipc_handlers_ts_TestLog.md
+++ b/log_tests/T003.2.4_Create_ipc_handlers_ts_TestLog.md
@@ -1,0 +1,106 @@
+# Test Log: T003.2.4 - Create desktop-app/src/main/ipc-handlers.ts
+
+## Test Information
+- **Task ID**: T003.2.4
+- **Test File**: `tests/desktop_app/test_T003_2_4_ipc_handlers.py`
+- **Date**: 2025-12-16
+- **Framework**: pytest 9.0.2
+- **Status**: ✅ All Tests Passed
+
+## Test Results Summary
+
+| Test Name | Status | Duration |
+|-----------|--------|----------|
+| test_ipc_handlers_ts_exists | ✅ PASSED | <0.01s |
+| test_ipc_handlers_ts_is_not_empty | ✅ PASSED | <0.01s |
+| test_ipc_handlers_imports_ipc_main | ✅ PASSED | <0.01s |
+| test_ipc_handlers_has_register_function | ✅ PASSED | <0.01s |
+| test_ipc_handlers_has_handle_method | ✅ PASSED | <0.01s |
+| test_ipc_handlers_has_ai_service_handlers | ✅ PASSED | <0.01s |
+| test_ipc_handlers_has_bridge_handlers | ✅ PASSED | <0.01s |
+| test_ipc_handlers_has_database_handlers | ✅ PASSED | <0.01s |
+| test_ipc_handlers_has_export | ✅ PASSED | <0.01s |
+| test_ipc_handlers_has_async_handlers | ✅ PASSED | <0.01s |
+
+**Total**: 10 passed in 0.04s
+
+## TDD Workflow
+
+### Red Phase (Tests Fail)
+Initial test run before creating ipc-handlers.ts:
+```
+FAILED test_ipc_handlers_ts_exists - AssertionError
+FAILED test_ipc_handlers_ts_is_not_empty - FileNotFoundError
+FAILED test_ipc_handlers_imports_ipc_main - FileNotFoundError
+FAILED test_ipc_handlers_has_register_function - FileNotFoundError
+FAILED test_ipc_handlers_has_handle_method - FileNotFoundError
+FAILED test_ipc_handlers_has_ai_service_handlers - FileNotFoundError
+FAILED test_ipc_handlers_has_bridge_handlers - FileNotFoundError
+FAILED test_ipc_handlers_has_database_handlers - FileNotFoundError
+FAILED test_ipc_handlers_has_export - FileNotFoundError
+FAILED test_ipc_handlers_has_async_handlers - FileNotFoundError
+========================= 10 failed in 0.19s ==========================
+```
+
+### Green Phase (Tests Pass)
+After creating ipc-handlers.ts stub:
+```
+tests/desktop_app/test_T003_2_4_ipc_handlers.py::TestIpcHandlersTs::test_ipc_handlers_ts_exists PASSED [ 10%]
+tests/desktop_app/test_T003_2_4_ipc_handlers.py::TestIpcHandlersTs::test_ipc_handlers_ts_is_not_empty PASSED [ 20%]
+tests/desktop_app/test_T003_2_4_ipc_handlers.py::TestIpcHandlersTs::test_ipc_handlers_imports_ipc_main PASSED [ 30%]
+tests/desktop_app/test_T003_2_4_ipc_handlers.py::TestIpcHandlersTs::test_ipc_handlers_has_register_function PASSED [ 40%]
+tests/desktop_app/test_T003_2_4_ipc_handlers.py::TestIpcHandlersTs::test_ipc_handlers_has_handle_method PASSED [ 50%]
+tests/desktop_app/test_T003_2_4_ipc_handlers.py::TestIpcHandlersTs::test_ipc_handlers_has_ai_service_handlers PASSED [ 60%]
+tests/desktop_app/test_T003_2_4_ipc_handlers.py::TestIpcHandlersTs::test_ipc_handlers_has_bridge_handlers PASSED [ 70%]
+tests/desktop_app/test_T003_2_4_ipc_handlers.py::TestIpcHandlersTs::test_ipc_handlers_has_database_handlers PASSED [ 80%]
+tests/desktop_app/test_T003_2_4_ipc_handlers.py::TestIpcHandlersTs::test_ipc_handlers_has_export PASSED [ 90%]
+tests/desktop_app/test_T003_2_4_ipc_handlers.py::TestIpcHandlersTs::test_ipc_handlers_has_async_handlers PASSED [100%]
+============================== 10 passed in 0.04s ===============================
+```
+
+## Test Cases Description
+
+### test_ipc_handlers_ts_exists
+**Purpose**: Verify ipc-handlers.ts exists in src/main directory
+**Assertion**: `os.path.isfile(IPC_HANDLERS_PATH)` returns True
+
+### test_ipc_handlers_ts_is_not_empty
+**Purpose**: Verify file has content
+**Assertion**: `len(content.strip()) > 0`
+
+### test_ipc_handlers_imports_ipc_main
+**Purpose**: Verify ipcMain is imported from electron
+**Assertion**: "ipcMain" in content
+
+### test_ipc_handlers_has_register_function
+**Purpose**: Verify handler registration function exists
+**Assertion**: "registerHandlers" or similar in content
+
+### test_ipc_handlers_has_handle_method
+**Purpose**: Verify ipcMain.handle is used for invoke channels
+**Assertion**: "handle" in content
+
+### test_ipc_handlers_has_ai_service_handlers
+**Purpose**: Verify AI service IPC handlers are defined
+**Assertion**: "ai:" or "extract" or "aiService" in content
+
+### test_ipc_handlers_has_bridge_handlers
+**Purpose**: Verify Windows Bridge handlers are defined
+**Assertion**: "bridge:" or "bridgeService" in content
+
+### test_ipc_handlers_has_database_handlers
+**Purpose**: Verify database handlers are defined
+**Assertion**: "db:" or "database" or "invoice" in content
+
+### test_ipc_handlers_has_export
+**Purpose**: Verify functions are exported
+**Assertion**: "export" in content
+
+### test_ipc_handlers_has_async_handlers
+**Purpose**: Verify async handlers are used
+**Assertion**: "async" in content
+
+## Test Command
+```bash
+python -m pytest tests/desktop_app/test_T003_2_4_ipc_handlers.py -v
+```

--- a/specs/001-windows-native-ai/tasks.md
+++ b/specs/001-windows-native-ai/tasks.md
@@ -198,7 +198,7 @@
     - Test: `tests/desktop_app/test_T003_1_4_electron_builder.py` (13 tests passed)
     - Logs: `log_files/T003.1.4_*`, `log_tests/T003.1.4_*`, `log_learn/T003.1.4_*`
 
-- [ ] **T003.2** [P] Create Electron main process structure
+- [x] **T003.2** [P] Create Electron main process structure ✅ *Completed 2025-12-16*
   - [x] T003.2.1 Create `desktop-app/src/main/index.ts` entry point ✅ *Completed 2025-12-16*
     - Created: `desktop-app/src/main/index.ts` with Electron main process entry point
     - Imports: app, BrowserWindow, ipcMain from electron
@@ -223,7 +223,14 @@
     - Exports: ProcessManager class, processManager singleton, ServiceHealth interface
     - Test: `tests/desktop_app/test_T003_2_3_process_manager.py` (10 tests passed)
     - Logs: `log_files/T003.2.3_*`, `log_tests/T003.2.3_*`, `log_learn/T003.2.3_*`
-  - [ ] T003.2.4 Create `desktop-app/src/main/ipc-handlers.ts` stub
+  - [x] T003.2.4 Create `desktop-app/src/main/ipc-handlers.ts` stub ✅ *Completed 2025-12-16*
+    - Created: `desktop-app/src/main/ipc-handlers.ts` with IPC handler stubs
+    - Handlers: AI Service (3), Bridge Service (6), Database (5), App (4), Window (3)
+    - Channels: ai:*, bridge:*, db:*, app:*, window:* matching preload.ts
+    - Functions: registerHandlers(), unregisterHandlers(), per-category registers
+    - Integration: Uses processManager for health checks, dialog for file picker
+    - Test: `tests/desktop_app/test_T003_2_4_ipc_handlers.py` (10 tests passed)
+    - Logs: `log_files/T003.2.4_*`, `log_tests/T003.2.4_*`, `log_learn/T003.2.4_*`
 
 - [ ] **T003.3** [P] Create React renderer structure
   - [ ] T003.3.1 Create `desktop-app/src/renderer/index.html`

--- a/tests/desktop_app/test_T003_2_4_ipc_handlers.py
+++ b/tests/desktop_app/test_T003_2_4_ipc_handlers.py
@@ -1,0 +1,122 @@
+"""
+Tests for T003.2.4: Create desktop-app/src/main/ipc-handlers.ts stub
+
+Tests verify that the IPC handlers stub exists and contains
+the required structure for handling IPC communication from renderer.
+"""
+
+import os
+
+import pytest
+
+
+# Path to the ipc-handlers.ts file
+IPC_HANDLERS_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+    "desktop-app",
+    "src",
+    "main",
+    "ipc-handlers.ts",
+)
+
+
+class TestIpcHandlersTs:
+    """Test suite for desktop-app/src/main/ipc-handlers.ts."""
+
+    def test_ipc_handlers_ts_exists(self):
+        """Test that ipc-handlers.ts exists in src/main directory."""
+        assert os.path.isfile(IPC_HANDLERS_PATH), (
+            f"ipc-handlers.ts not found at {IPC_HANDLERS_PATH}"
+        )
+
+    def test_ipc_handlers_ts_is_not_empty(self):
+        """Test that ipc-handlers.ts has content."""
+        with open(IPC_HANDLERS_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        assert len(content.strip()) > 0, "ipc-handlers.ts must not be empty"
+
+    def test_ipc_handlers_imports_ipc_main(self):
+        """Test that ipc-handlers.ts imports ipcMain from electron."""
+        with open(IPC_HANDLERS_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "ipcMain" in content, (
+            "ipc-handlers.ts must import ipcMain from electron"
+        )
+
+    def test_ipc_handlers_has_register_function(self):
+        """Test that ipc-handlers.ts has a register handlers function."""
+        with open(IPC_HANDLERS_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        has_register = (
+            "registerHandlers" in content or
+            "registerIpcHandlers" in content or
+            "setupHandlers" in content or
+            "initHandlers" in content
+        )
+        assert has_register, (
+            "ipc-handlers.ts must have a register/setup handlers function"
+        )
+
+    def test_ipc_handlers_has_handle_method(self):
+        """Test that ipc-handlers.ts uses ipcMain.handle for invoke channels."""
+        with open(IPC_HANDLERS_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "handle" in content, (
+            "ipc-handlers.ts must use ipcMain.handle for invoke channels"
+        )
+
+    def test_ipc_handlers_has_ai_service_handlers(self):
+        """Test that ipc-handlers.ts has AI service handlers."""
+        with open(IPC_HANDLERS_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        has_ai_handlers = (
+            "ai:" in content or
+            "extract" in content or
+            "aiService" in content or
+            "AI" in content
+        )
+        assert has_ai_handlers, (
+            "ipc-handlers.ts must have AI service handlers"
+        )
+
+    def test_ipc_handlers_has_bridge_handlers(self):
+        """Test that ipc-handlers.ts has Windows Bridge handlers."""
+        with open(IPC_HANDLERS_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        has_bridge_handlers = (
+            "bridge:" in content or
+            "bridgeService" in content or
+            "Bridge" in content
+        )
+        assert has_bridge_handlers, (
+            "ipc-handlers.ts must have Windows Bridge handlers"
+        )
+
+    def test_ipc_handlers_has_database_handlers(self):
+        """Test that ipc-handlers.ts has database handlers."""
+        with open(IPC_HANDLERS_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        has_db_handlers = (
+            "db:" in content or
+            "database" in content or
+            "invoice" in content.lower()
+        )
+        assert has_db_handlers, (
+            "ipc-handlers.ts must have database handlers"
+        )
+
+    def test_ipc_handlers_has_export(self):
+        """Test that ipc-handlers.ts exports its functions."""
+        with open(IPC_HANDLERS_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "export" in content, (
+            "ipc-handlers.ts must export its functions"
+        )
+
+    def test_ipc_handlers_has_async_handlers(self):
+        """Test that ipc-handlers.ts uses async handlers."""
+        with open(IPC_HANDLERS_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "async" in content, (
+            "ipc-handlers.ts should use async handlers for IPC operations"
+        )


### PR DESCRIPTION
Add IPC handlers stub for main process communication:
- AI Service handlers: extract-invoice, check-health, get-status
- Bridge Service handlers: check-health, get-vendors, create-entry, etc.
- Database handlers: get-invoices, save-invoice, update, delete
- App handlers: get-version, get-config, open-file-dialog, save-file-dialog
- Window handlers: minimize, maximize, close

Integrates with processManager for health checks and dialog for file pickers. Channels match preload.ts whitelist.

Completes T003.2 (Create Electron main process structure) task group.

TDD: 10 tests passed