### PR TITLE
feat(T003.3.4): create desktop-app/src/renderer/types/index.ts

### DIFF
--- a/desktop-app/src/renderer/types/index.ts
+++ b/desktop-app/src/renderer/types/index.ts
@@ -1,0 +1,294 @@
+/**
+ * ContPAQ Win - TypeScript Type Definitions
+ *
+ * This file contains all TypeScript interfaces and types used
+ * throughout the desktop application renderer process.
+ */
+
+// =============================================================================
+// Enums and Type Aliases
+// =============================================================================
+
+/**
+ * Invoice processing state.
+ * Follows the workflow: UPLOADED → EXTRACTED → VALIDATED → POSTED
+ */
+export type InvoiceState = 'UPLOADED' | 'EXTRACTED' | 'VALIDATED' | 'POSTED';
+
+/**
+ * Source type of the PDF document.
+ * - text_based: PDF with embedded text (can be extracted directly)
+ * - scanned: PDF is an image that requires OCR
+ */
+export type SourceType = 'text_based' | 'scanned';
+
+/**
+ * Status of posting to ContPAQi system.
+ */
+export type PostingStatus = 'pending' | 'success' | 'failed';
+
+/**
+ * Service health status for AI and Bridge services.
+ */
+export type ServiceStatus = 'stopped' | 'starting' | 'running' | 'stopping' | 'error';
+
+// =============================================================================
+// Geometry Types
+// =============================================================================
+
+/**
+ * Bounding box coordinates for extracted field locations.
+ * Used for highlighting fields in the PDF viewer.
+ */
+export interface BoundingBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+// =============================================================================
+// Extraction Types
+// =============================================================================
+
+/**
+ * Result of AI extraction for a single field.
+ * Includes confidence score and optional bounding box for visualization.
+ */
+export interface ExtractionField {
+  fieldName: string;
+  value: string;
+  confidence: number; // 0-100
+  bbox?: BoundingBox;
+  userVerified: boolean;
+}
+
+/**
+ * Extraction result for a line item.
+ */
+export interface LineItemExtraction {
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  amount: number;
+  confidence: number; // 0-100
+}
+
+/**
+ * Complete invoice extraction response from AI service.
+ */
+export interface InvoiceExtraction {
+  vendorRfc: ExtractionField;
+  vendorName: ExtractionField;
+  invoiceNumber: ExtractionField;
+  invoiceDate: ExtractionField;
+  subtotal: ExtractionField;
+  ivaAmount: ExtractionField;
+  total: ExtractionField;
+  lineItems: LineItemExtraction[];
+  sourceType: SourceType;
+  processingTimeMs: number;
+}
+
+// =============================================================================
+// Entity Types
+// =============================================================================
+
+/**
+ * Line item from an invoice.
+ */
+export interface LineItem {
+  id: string;
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  amount: number;
+  lineOrder: number;
+}
+
+/**
+ * Vendor (supplier) information.
+ * Corresponds to a provider in ContPAQi.
+ */
+export interface Vendor {
+  id: string;
+  rfc: string;
+  businessName: string;
+  address?: string;
+  contactInfo?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+/**
+ * Invoice entity with all related data.
+ */
+export interface Invoice {
+  id: string;
+  vendor?: Vendor;
+  vendorId?: string;
+  invoiceNumber: string;
+  invoiceDate: string; // ISO date format
+  subtotal: number;
+  ivaAmount: number;
+  total: number;
+  state: InvoiceState;
+  sourceType: SourceType;
+  pdfPath: string;
+  duplicateHash?: string;
+  lineItems: LineItem[];
+  extractionResults: ExtractionField[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Record of posting to ContPAQi system.
+ */
+export interface ContPAQiEntry {
+  id: string;
+  invoiceId: string;
+  folioNumber?: string;
+  entryDate: string;
+  postingStatus: PostingStatus;
+  errorMessage?: string;
+  createdAt: string;
+}
+
+// =============================================================================
+// Service Types
+// =============================================================================
+
+/**
+ * Health check response from a service.
+ */
+export interface ServiceHealth {
+  status: ServiceStatus;
+  healthy: boolean;
+  message?: string;
+  version?: string;
+  timestamp: string;
+}
+
+/**
+ * Combined status of all backend services.
+ */
+export interface ServicesStatus {
+  aiService: ServiceHealth;
+  bridgeService: ServiceHealth;
+}
+
+// =============================================================================
+// API Response Types
+// =============================================================================
+
+/**
+ * Generic API response wrapper.
+ */
+export interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  message?: string;
+}
+
+/**
+ * Paginated list response.
+ */
+export interface PaginatedResponse<T> {
+  items: T[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+/**
+ * Invoice filter options for listing.
+ */
+export interface InvoiceFilters {
+  state?: InvoiceState;
+  vendorId?: string;
+  startDate?: string;
+  endDate?: string;
+  searchQuery?: string;
+}
+
+// =============================================================================
+// Electron IPC Types
+// =============================================================================
+
+/**
+ * ElectronAPI interface exposed via preload script.
+ * Provides type-safe access to IPC communication.
+ */
+export interface ElectronAPI {
+  /**
+   * Invoke an IPC handler and wait for response.
+   */
+  invoke: (channel: string, ...args: unknown[]) => Promise<unknown>;
+
+  /**
+   * Send a one-way message (fire and forget).
+   */
+  send: (channel: string, ...args: unknown[]) => void;
+
+  /**
+   * Subscribe to messages from main process.
+   */
+  on: (channel: string, callback: (...args: unknown[]) => void) => void;
+
+  /**
+   * Remove a specific listener.
+   */
+  removeListener: (channel: string, callback: (...args: unknown[]) => void) => void;
+
+  /**
+   * Remove all listeners for a channel.
+   */
+  removeAllListeners: (channel: string) => void;
+}
+
+// =============================================================================
+// Window Type Augmentation
+// =============================================================================
+
+/**
+ * Extend the global Window interface to include electronAPI.
+ */
+declare global {
+  interface Window {
+    electronAPI: ElectronAPI;
+  }
+}
+
+// =============================================================================
+// Component Prop Types
+// =============================================================================
+
+/**
+ * Props for confidence indicator component.
+ */
+export interface ConfidenceIndicatorProps {
+  confidence: number;
+  showPercentage?: boolean;
+}
+
+/**
+ * Confidence level thresholds.
+ */
+export const CONFIDENCE_THRESHOLDS = {
+  HIGH: 90,
+  MEDIUM: 70,
+} as const;
+
+/**
+ * Get confidence level based on value.
+ */
+export type ConfidenceLevel = 'high' | 'medium' | 'low';
+
+export function getConfidenceLevel(confidence: number): ConfidenceLevel {
+  if (confidence >= CONFIDENCE_THRESHOLDS.HIGH) return 'high';
+  if (confidence >= CONFIDENCE_THRESHOLDS.MEDIUM) return 'medium';
+  return 'low';
+}

--- a/log_files/T003.3.4_Create_types_index_Log.md
+++ b/log_files/T003.3.4_Create_types_index_Log.md
@@ -1,0 +1,130 @@
+# Implementation Log: T003.3.4 - Create desktop-app/src/renderer/types/index.ts
+
+## Task Information
+- **Task ID**: T003.3.4
+- **Task Name**: Create `desktop-app/src/renderer/types/index.ts` with TypeScript interfaces
+- **Parent Task**: T003.3 - Create React renderer structure
+- **Date**: 2025-12-16
+- **Status**: ✅ Completed
+
+## Implementation Details
+
+### Objective
+Create comprehensive TypeScript type definitions for all data models and interfaces used in the desktop application.
+
+### File Created
+
+**Location**: `desktop-app/src/renderer/types/index.ts`
+
+### Type Categories
+
+#### 1. Enums and Type Aliases
+
+| Type | Values | Purpose |
+|------|--------|---------|
+| `InvoiceState` | 'UPLOADED' \| 'EXTRACTED' \| 'VALIDATED' \| 'POSTED' | Invoice workflow states |
+| `SourceType` | 'text_based' \| 'scanned' | PDF type classification |
+| `PostingStatus` | 'pending' \| 'success' \| 'failed' | ContPAQi posting status |
+| `ServiceStatus` | 'stopped' \| 'starting' \| 'running' \| 'stopping' \| 'error' | Service health |
+| `ConfidenceLevel` | 'high' \| 'medium' \| 'low' | Extraction confidence |
+
+#### 2. Geometry Types
+
+| Interface | Fields | Purpose |
+|-----------|--------|---------|
+| `BoundingBox` | x, y, width, height | Field location in PDF |
+
+#### 3. Extraction Types
+
+| Interface | Description |
+|-----------|-------------|
+| `ExtractionField` | Single field with value, confidence, bbox |
+| `LineItemExtraction` | Line item with quantities and amounts |
+| `InvoiceExtraction` | Complete AI extraction response |
+
+#### 4. Entity Types
+
+| Interface | Description |
+|-----------|-------------|
+| `LineItem` | Invoice line item |
+| `Vendor` | Supplier/vendor information |
+| `Invoice` | Complete invoice with all relations |
+| `ContPAQiEntry` | Record of posting to ContPAQi |
+
+#### 5. Service Types
+
+| Interface | Description |
+|-----------|-------------|
+| `ServiceHealth` | Health check response |
+| `ServicesStatus` | Combined AI and Bridge status |
+
+#### 6. API Response Types
+
+| Interface | Description |
+|-----------|-------------|
+| `ApiResponse<T>` | Generic response wrapper |
+| `PaginatedResponse<T>` | List with pagination |
+| `InvoiceFilters` | Filter options for queries |
+
+#### 7. Electron IPC Types
+
+| Interface | Description |
+|-----------|-------------|
+| `ElectronAPI` | Preload script interface |
+| `Window` (augmented) | Global window type extension |
+
+### Design Decisions
+
+1. **Type Aliases vs Enums**: Used string literal unions for flexibility with JSON serialization
+
+2. **Optional Fields**: Marked with `?` for nullable database fields
+
+3. **Generic Types**: `ApiResponse<T>` and `PaginatedResponse<T>` for reusability
+
+4. **Global Window Extension**: Augments Window interface for type-safe `window.electronAPI`
+
+5. **Confidence Thresholds**: Constants exported for consistent confidence level checking
+
+### Exports
+
+```typescript
+// Type aliases
+export type InvoiceState = ...
+export type SourceType = ...
+export type PostingStatus = ...
+export type ServiceStatus = ...
+export type ConfidenceLevel = ...
+
+// Interfaces
+export interface BoundingBox { ... }
+export interface ExtractionField { ... }
+export interface LineItem { ... }
+export interface Vendor { ... }
+export interface Invoice { ... }
+export interface ContPAQiEntry { ... }
+export interface ServiceHealth { ... }
+export interface ElectronAPI { ... }
+
+// Constants and utilities
+export const CONFIDENCE_THRESHOLDS = { ... }
+export function getConfidenceLevel(confidence: number): ConfidenceLevel
+```
+
+### Verification
+- All 14 tests passed successfully
+- All entity interfaces defined
+- All type aliases defined
+- ElectronAPI interface for preload
+- Window type augmentation
+
+## Related Files
+- Test file: `tests/desktop_app/test_T003_3_4_types_index.py`
+- Test log: `log_tests/T003.3.4_Create_types_index_TestLog.md`
+- Learn guide: `log_learn/T003.3.4_Create_types_index_Guide.md`
+- Source: `specs/001-windows-native-ai/data-model.md`
+- Related: `preload.ts` (ElectronAPI matches)
+
+## Next Steps
+- T003.4: Create i18n structure (Spanish)
+- Import types in components as needed
+- Add more specific types as features are developed

--- a/log_learn/T003.3.4_Create_types_index_Guide.md
+++ b/log_learn/T003.3.4_Create_types_index_Guide.md
@@ -1,0 +1,322 @@
+# Learning Guide: T003.3.4 - Create desktop-app/src/renderer/types/index.ts
+
+## Overview
+
+This guide covers creating comprehensive TypeScript type definitions for a desktop application, including entity interfaces, API types, and Electron IPC types.
+
+## Concepts Covered
+
+### 1. Type Aliases vs Enums
+
+TypeScript offers two main ways to define fixed sets of values:
+
+```typescript
+// String literal union (preferred for JSON)
+type InvoiceState = 'UPLOADED' | 'EXTRACTED' | 'VALIDATED' | 'POSTED';
+
+// Enum (creates runtime object)
+enum InvoiceStateEnum {
+  UPLOADED = 'UPLOADED',
+  EXTRACTED = 'EXTRACTED',
+  VALIDATED = 'VALIDATED',
+  POSTED = 'POSTED',
+}
+```
+
+**Why use string literals?**
+- No runtime overhead
+- Better JSON serialization
+- Easier to use with API responses
+- Type narrowing works naturally
+
+### 2. Interface Design Patterns
+
+Structure interfaces to match your data model:
+
+```typescript
+// Basic entity interface
+interface Vendor {
+  id: string;
+  rfc: string;
+  businessName: string;
+  address?: string;        // Optional field
+  contactInfo?: string;    // Optional field
+}
+
+// Entity with relationships
+interface Invoice {
+  id: string;
+  vendor?: Vendor;         // Optional relation
+  vendorId?: string;       // Foreign key
+  lineItems: LineItem[];   // One-to-many
+}
+```
+
+### 3. Generic Response Types
+
+Create reusable types for API responses:
+
+```typescript
+// Generic wrapper
+interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}
+
+// Paginated response
+interface PaginatedResponse<T> {
+  items: T[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+// Usage
+type InvoiceResponse = ApiResponse<Invoice>;
+type InvoiceListResponse = PaginatedResponse<Invoice>;
+```
+
+### 4. Extending Global Types
+
+Augment the Window interface for Electron:
+
+```typescript
+// Define the API interface
+interface ElectronAPI {
+  invoke: (channel: string, ...args: unknown[]) => Promise<unknown>;
+  send: (channel: string, ...args: unknown[]) => void;
+  on: (channel: string, callback: (...args: unknown[]) => void) => void;
+}
+
+// Augment global Window
+declare global {
+  interface Window {
+    electronAPI: ElectronAPI;
+  }
+}
+
+// Now TypeScript knows about window.electronAPI
+window.electronAPI.invoke('ai:extract-invoice', filePath);
+```
+
+### 5. Constants and Utility Functions
+
+Export related constants and helpers:
+
+```typescript
+// Constants
+export const CONFIDENCE_THRESHOLDS = {
+  HIGH: 90,
+  MEDIUM: 70,
+} as const;
+
+// Type from constants
+type ConfidenceLevel = 'high' | 'medium' | 'low';
+
+// Utility function
+export function getConfidenceLevel(confidence: number): ConfidenceLevel {
+  if (confidence >= CONFIDENCE_THRESHOLDS.HIGH) return 'high';
+  if (confidence >= CONFIDENCE_THRESHOLDS.MEDIUM) return 'medium';
+  return 'low';
+}
+```
+
+## Code Example
+
+### Complete Types File Structure
+
+```typescript
+/**
+ * Application Type Definitions
+ */
+
+// =============================================================================
+// Type Aliases
+// =============================================================================
+
+export type InvoiceState = 'UPLOADED' | 'EXTRACTED' | 'VALIDATED' | 'POSTED';
+export type SourceType = 'text_based' | 'scanned';
+export type ServiceStatus = 'stopped' | 'starting' | 'running' | 'error';
+
+// =============================================================================
+// Geometry Types
+// =============================================================================
+
+export interface BoundingBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+// =============================================================================
+// Entity Types
+// =============================================================================
+
+export interface Vendor {
+  id: string;
+  rfc: string;
+  businessName: string;
+}
+
+export interface Invoice {
+  id: string;
+  vendor?: Vendor;
+  invoiceNumber: string;
+  total: number;
+  state: InvoiceState;
+}
+
+// =============================================================================
+// API Types
+// =============================================================================
+
+export interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}
+
+// =============================================================================
+// Electron Types
+// =============================================================================
+
+export interface ElectronAPI {
+  invoke: (channel: string, ...args: unknown[]) => Promise<unknown>;
+  send: (channel: string, ...args: unknown[]) => void;
+}
+
+declare global {
+  interface Window {
+    electronAPI: ElectronAPI;
+  }
+}
+```
+
+## Best Practices
+
+### 1. Organize by Category
+
+Group related types together:
+
+```typescript
+// ❌ Mixed types
+interface User { ... }
+type Status = ...
+interface Product { ... }
+
+// ✅ Organized by category
+// --- Entity Types ---
+interface User { ... }
+interface Product { ... }
+
+// --- Status Types ---
+type Status = ...
+```
+
+### 2. Use Descriptive Names
+
+```typescript
+// ❌ Vague names
+interface Data { ... }
+type State = ...
+
+// ✅ Descriptive names
+interface InvoiceExtraction { ... }
+type InvoiceState = ...
+```
+
+### 3. Document Complex Types
+
+```typescript
+/**
+ * Result of AI extraction for a single field.
+ *
+ * @property fieldName - Name of the extracted field
+ * @property confidence - Confidence score from 0-100
+ * @property bbox - Optional bounding box for visualization
+ */
+export interface ExtractionField {
+  fieldName: string;
+  value: string;
+  confidence: number;
+  bbox?: BoundingBox;
+  userVerified: boolean;
+}
+```
+
+### 4. Export Everything Needed
+
+```typescript
+// Export types
+export type { InvoiceState, SourceType };
+
+// Export interfaces
+export type { Invoice, Vendor, LineItem };
+
+// Export constants
+export { CONFIDENCE_THRESHOLDS };
+
+// Export functions
+export { getConfidenceLevel };
+```
+
+## Type Import Patterns
+
+### Importing in Components
+
+```typescript
+// Import specific types
+import type { Invoice, Vendor, InvoiceState } from '../types';
+
+// Import everything
+import type * as Types from '../types';
+
+// Import values (constants, functions)
+import { CONFIDENCE_THRESHOLDS, getConfidenceLevel } from '../types';
+```
+
+### Type-Only Imports
+
+Use `import type` for types that don't need runtime:
+
+```typescript
+// Type-only import (removed during compilation)
+import type { Invoice } from '../types';
+
+// Regular import (kept for runtime values)
+import { getConfidenceLevel } from '../types';
+```
+
+## Common Issues
+
+### Issue: "Cannot find name 'Window'"
+**Cause**: Global augmentation not recognized
+**Solution**: Add `export {}` at end of file to make it a module
+
+### Issue: Type Not Exported
+**Cause**: Missing export keyword
+**Solution**: Add `export` before interface/type
+
+### Issue: Circular Dependencies
+**Cause**: Types importing each other
+**Solution**: Move shared types to common file
+
+## Summary
+
+Creating TypeScript types involves:
+1. ✅ Define type aliases for string unions
+2. ✅ Create interfaces for entities
+3. ✅ Use generics for reusable response types
+4. ✅ Augment global types for Electron
+5. ✅ Export constants and utility functions
+6. ✅ Organize by category with clear sections
+
+## References
+
+- [TypeScript Handbook - Types](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html)
+- [TypeScript Handbook - Generics](https://www.typescriptlang.org/docs/handbook/2/generics.html)
+- [Declaration Merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html)
+- [Module Augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation)

--- a/log_tests/T003.3.4_Create_types_index_TestLog.md
+++ b/log_tests/T003.3.4_Create_types_index_TestLog.md
@@ -1,0 +1,134 @@
+# Test Log: T003.3.4 - Create desktop-app/src/renderer/types/index.ts
+
+## Test Information
+- **Task ID**: T003.3.4
+- **Test File**: `tests/desktop_app/test_T003_3_4_types_index.py`
+- **Date**: 2025-12-16
+- **Framework**: pytest 9.0.2
+- **Status**: ✅ All Tests Passed
+
+## Test Results Summary
+
+| Test Name | Status | Duration |
+|-----------|--------|----------|
+| test_types_index_exists | ✅ PASSED | <0.01s |
+| test_types_index_is_not_empty | ✅ PASSED | <0.01s |
+| test_types_has_invoice_state | ✅ PASSED | <0.01s |
+| test_types_has_source_type | ✅ PASSED | <0.01s |
+| test_types_has_bounding_box_interface | ✅ PASSED | <0.01s |
+| test_types_has_extraction_field_interface | ✅ PASSED | <0.01s |
+| test_types_has_line_item_interface | ✅ PASSED | <0.01s |
+| test_types_has_vendor_interface | ✅ PASSED | <0.01s |
+| test_types_has_invoice_interface | ✅ PASSED | <0.01s |
+| test_types_has_contpaqi_entry_interface | ✅ PASSED | <0.01s |
+| test_types_has_posting_status | ✅ PASSED | <0.01s |
+| test_types_has_service_status | ✅ PASSED | <0.01s |
+| test_types_has_electron_api_interface | ✅ PASSED | <0.01s |
+| test_types_exports_all_interfaces | ✅ PASSED | <0.01s |
+
+**Total**: 14 passed in 0.06s
+
+## TDD Workflow
+
+### Red Phase (Tests Fail)
+Initial test run before creating types/index.ts:
+```
+FAILED test_types_index_exists - AssertionError
+FAILED test_types_index_is_not_empty - FileNotFoundError
+FAILED test_types_has_invoice_state - FileNotFoundError
+FAILED test_types_has_source_type - FileNotFoundError
+FAILED test_types_has_bounding_box_interface - FileNotFoundError
+FAILED test_types_has_extraction_field_interface - FileNotFoundError
+FAILED test_types_has_line_item_interface - FileNotFoundError
+FAILED test_types_has_vendor_interface - FileNotFoundError
+FAILED test_types_has_invoice_interface - FileNotFoundError
+FAILED test_types_has_contpaqi_entry_interface - FileNotFoundError
+FAILED test_types_has_posting_status - FileNotFoundError
+FAILED test_types_has_service_status - FileNotFoundError
+FAILED test_types_has_electron_api_interface - FileNotFoundError
+FAILED test_types_exports_all_interfaces - FileNotFoundError
+========================= 14 failed in 0.19s ==========================
+```
+
+### Green Phase (Tests Pass)
+After creating types/index.ts:
+```
+tests/desktop_app/test_T003_3_4_types_index.py::TestTypesIndex::test_types_index_exists PASSED [  7%]
+tests/desktop_app/test_T003_3_4_types_index.py::TestTypesIndex::test_types_index_is_not_empty PASSED [ 14%]
+tests/desktop_app/test_T003_3_4_types_index.py::TestTypesIndex::test_types_has_invoice_state PASSED [ 21%]
+tests/desktop_app/test_T003_3_4_types_index.py::TestTypesIndex::test_types_has_source_type PASSED [ 28%]
+tests/desktop_app/test_T003_3_4_types_index.py::TestTypesIndex::test_types_has_bounding_box_interface PASSED [ 35%]
+tests/desktop_app/test_T003_3_4_types_index.py::TestTypesIndex::test_types_has_extraction_field_interface PASSED [ 42%]
+tests/desktop_app/test_T003_3_4_types_index.py::TestTypesIndex::test_types_has_line_item_interface PASSED [ 50%]
+tests/desktop_app/test_T003_3_4_types_index.py::TestTypesIndex::test_types_has_vendor_interface PASSED [ 57%]
+tests/desktop_app/test_T003_3_4_types_index.py::TestTypesIndex::test_types_has_invoice_interface PASSED [ 64%]
+tests/desktop_app/test_T003_3_4_types_index.py::TestTypesIndex::test_types_has_contpaqi_entry_interface PASSED [ 71%]
+tests/desktop_app/test_T003_3_4_types_index.py::TestTypesIndex::test_types_has_posting_status PASSED [ 78%]
+tests/desktop_app/test_T003_3_4_types_index.py::TestTypesIndex::test_types_has_service_status PASSED [ 85%]
+tests/desktop_app/test_T003_3_4_types_index.py::TestTypesIndex::test_types_has_electron_api_interface PASSED [ 92%]
+tests/desktop_app/test_T003_3_4_types_index.py::TestTypesIndex::test_types_exports_all_interfaces PASSED [100%]
+============================== 14 passed in 0.06s ===============================
+```
+
+## Test Cases Description
+
+### test_types_index_exists
+**Purpose**: Verify types/index.ts exists in src/renderer/types directory
+**Assertion**: `os.path.isfile(TYPES_INDEX_PATH)` returns True
+
+### test_types_index_is_not_empty
+**Purpose**: Verify file has content
+**Assertion**: `len(content.strip()) > 0`
+
+### test_types_has_invoice_state
+**Purpose**: Verify InvoiceState type is defined
+**Assertion**: "InvoiceState" and "UPLOADED" in content
+
+### test_types_has_source_type
+**Purpose**: Verify SourceType type is defined
+**Assertion**: "SourceType" and "text_based" in content
+
+### test_types_has_bounding_box_interface
+**Purpose**: Verify BoundingBox interface is defined
+**Assertion**: "BoundingBox" and "width" and "height" in content
+
+### test_types_has_extraction_field_interface
+**Purpose**: Verify ExtractionField interface is defined
+**Assertion**: "ExtractionField" and "confidence" in content
+
+### test_types_has_line_item_interface
+**Purpose**: Verify LineItem interface is defined
+**Assertion**: "LineItem" and "quantity" and "unitPrice" in content
+
+### test_types_has_vendor_interface
+**Purpose**: Verify Vendor interface is defined
+**Assertion**: "Vendor" and "rfc" and "businessName" in content
+
+### test_types_has_invoice_interface
+**Purpose**: Verify Invoice interface is defined
+**Assertion**: "interface Invoice" and fields in content
+
+### test_types_has_contpaqi_entry_interface
+**Purpose**: Verify ContPAQiEntry interface is defined
+**Assertion**: "ContPAQiEntry" and "folioNumber" in content
+
+### test_types_has_posting_status
+**Purpose**: Verify PostingStatus type is defined
+**Assertion**: "PostingStatus" and status values in content
+
+### test_types_has_service_status
+**Purpose**: Verify ServiceStatus type is defined
+**Assertion**: "ServiceStatus" or "ServiceHealth" in content
+
+### test_types_has_electron_api_interface
+**Purpose**: Verify ElectronAPI interface is defined
+**Assertion**: "ElectronAPI" and "invoke" in content
+
+### test_types_exports_all_interfaces
+**Purpose**: Verify types are exported
+**Assertion**: "export" in content
+
+## Test Command
+```bash
+python -m pytest tests/desktop_app/test_T003_3_4_types_index.py -v
+```

--- a/specs/001-windows-native-ai/tasks.md
+++ b/specs/001-windows-native-ai/tasks.md
@@ -232,7 +232,7 @@
     - Test: `tests/desktop_app/test_T003_2_4_ipc_handlers.py` (10 tests passed)
     - Logs: `log_files/T003.2.4_*`, `log_tests/T003.2.4_*`, `log_learn/T003.2.4_*`
 
-- [ ] **T003.3** [P] Create React renderer structure
+- [x] **T003.3** [P] Create React renderer structure ✅ *Completed 2025-12-16*
   - [x] T003.3.1 Create `desktop-app/src/renderer/index.html` ✅ *Completed 2025-12-16*
     - Created: `desktop-app/src/renderer/index.html` with HTML5 entry point
     - Features: Spanish lang (lang="es"), UTF-8 charset, viewport meta, CSP headers
@@ -255,7 +255,15 @@
     - Styling: Tailwind CSS with flex layout, responsive design
     - Test: `tests/desktop_app/test_T003_3_3_app_tsx.py` (12 tests passed)
     - Logs: `log_files/T003.3.3_*`, `log_tests/T003.3.3_*`, `log_learn/T003.3.3_*`
-  - [ ] T003.3.4 Create `desktop-app/src/renderer/types/index.ts` with TypeScript interfaces
+  - [x] T003.3.4 Create `desktop-app/src/renderer/types/index.ts` with TypeScript interfaces ✅ *Completed 2025-12-16*
+    - Created: `desktop-app/src/renderer/types/index.ts` with all type definitions
+    - Types: InvoiceState, SourceType, PostingStatus, ServiceStatus, ConfidenceLevel
+    - Interfaces: BoundingBox, ExtractionField, LineItem, Vendor, Invoice, ContPAQiEntry
+    - API: ApiResponse<T>, PaginatedResponse<T>, InvoiceFilters
+    - Electron: ElectronAPI interface, Window type augmentation
+    - Utilities: CONFIDENCE_THRESHOLDS, getConfidenceLevel()
+    - Test: `tests/desktop_app/test_T003_3_4_types_index.py` (14 tests passed)
+    - Logs: `log_files/T003.3.4_*`, `log_tests/T003.3.4_*`, `log_learn/T003.3.4_*`
 
 - [ ] **T003.4** [P] Create i18n structure (Spanish)
   - [ ] T003.4.1 Create `desktop-app/src/renderer/i18n/es.json` with all UI strings

--- a/tests/desktop_app/test_T003_3_4_types_index.py
+++ b/tests/desktop_app/test_T003_3_4_types_index.py
@@ -1,0 +1,185 @@
+"""
+Tests for T003.3.4: Create desktop-app/src/renderer/types/index.ts
+
+Tests verify that the TypeScript interfaces file exists and contains
+all required type definitions for the application data models.
+"""
+
+import os
+
+import pytest
+
+
+# Path to the types/index.ts file
+TYPES_INDEX_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+    "desktop-app",
+    "src",
+    "renderer",
+    "types",
+    "index.ts",
+)
+
+
+class TestTypesIndex:
+    """Test suite for desktop-app/src/renderer/types/index.ts."""
+
+    def test_types_index_exists(self):
+        """Test that index.ts exists in src/renderer/types directory."""
+        assert os.path.isfile(TYPES_INDEX_PATH), (
+            f"types/index.ts not found at {TYPES_INDEX_PATH}"
+        )
+
+    def test_types_index_is_not_empty(self):
+        """Test that types/index.ts has content."""
+        with open(TYPES_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        assert len(content.strip()) > 0, "types/index.ts must not be empty"
+
+    def test_types_has_invoice_state(self):
+        """Test that types defines InvoiceState type."""
+        with open(TYPES_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        has_invoice_state = (
+            "InvoiceState" in content and
+            ("UPLOADED" in content or "'UPLOADED'" in content or '"UPLOADED"' in content)
+        )
+        assert has_invoice_state, (
+            "types/index.ts must define InvoiceState type with UPLOADED state"
+        )
+
+    def test_types_has_source_type(self):
+        """Test that types defines SourceType type."""
+        with open(TYPES_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        has_source_type = (
+            "SourceType" in content and
+            "text_based" in content
+        )
+        assert has_source_type, (
+            "types/index.ts must define SourceType type"
+        )
+
+    def test_types_has_bounding_box_interface(self):
+        """Test that types defines BoundingBox interface."""
+        with open(TYPES_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        has_bbox = (
+            "BoundingBox" in content and
+            "width" in content and
+            "height" in content
+        )
+        assert has_bbox, (
+            "types/index.ts must define BoundingBox interface"
+        )
+
+    def test_types_has_extraction_field_interface(self):
+        """Test that types defines ExtractionField interface."""
+        with open(TYPES_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        has_extraction = (
+            "ExtractionField" in content and
+            "confidence" in content
+        )
+        assert has_extraction, (
+            "types/index.ts must define ExtractionField interface"
+        )
+
+    def test_types_has_line_item_interface(self):
+        """Test that types defines LineItem interface."""
+        with open(TYPES_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        has_line_item = (
+            "LineItem" in content and
+            "quantity" in content and
+            "unitPrice" in content
+        )
+        assert has_line_item, (
+            "types/index.ts must define LineItem interface"
+        )
+
+    def test_types_has_vendor_interface(self):
+        """Test that types defines Vendor interface."""
+        with open(TYPES_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        has_vendor = (
+            "Vendor" in content and
+            "rfc" in content and
+            "businessName" in content
+        )
+        assert has_vendor, (
+            "types/index.ts must define Vendor interface with rfc and businessName"
+        )
+
+    def test_types_has_invoice_interface(self):
+        """Test that types defines Invoice interface."""
+        with open(TYPES_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        has_invoice = (
+            "interface Invoice" in content and
+            "invoiceNumber" in content and
+            "subtotal" in content and
+            "ivaAmount" in content
+        )
+        assert has_invoice, (
+            "types/index.ts must define Invoice interface"
+        )
+
+    def test_types_has_contpaqi_entry_interface(self):
+        """Test that types defines ContPAQiEntry interface."""
+        with open(TYPES_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        has_entry = (
+            "ContPAQiEntry" in content and
+            "folioNumber" in content
+        )
+        assert has_entry, (
+            "types/index.ts must define ContPAQiEntry interface"
+        )
+
+    def test_types_has_posting_status(self):
+        """Test that types defines PostingStatus type."""
+        with open(TYPES_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        has_posting = (
+            "PostingStatus" in content and
+            "pending" in content and
+            "success" in content and
+            "failed" in content
+        )
+        assert has_posting, (
+            "types/index.ts must define PostingStatus type"
+        )
+
+    def test_types_has_service_status(self):
+        """Test that types defines ServiceStatus for health monitoring."""
+        with open(TYPES_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        has_service_status = (
+            "ServiceStatus" in content or
+            "ServiceHealth" in content
+        )
+        assert has_service_status, (
+            "types/index.ts must define ServiceStatus or ServiceHealth type"
+        )
+
+    def test_types_has_electron_api_interface(self):
+        """Test that types defines ElectronAPI interface for preload."""
+        with open(TYPES_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        has_electron_api = (
+            "ElectronAPI" in content and
+            "invoke" in content
+        )
+        assert has_electron_api, (
+            "types/index.ts must define ElectronAPI interface"
+        )
+
+    def test_types_exports_all_interfaces(self):
+        """Test that types exports its definitions."""
+        with open(TYPES_INDEX_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+        has_export = "export" in content
+        assert has_export, (
+            "types/index.ts must export its type definitions"
+        )


### PR DESCRIPTION
Comprehensive TypeScript type definitions including:
- Type aliases: InvoiceState, SourceType, PostingStatus, ServiceStatus
- Entity interfaces: Invoice, Vendor, LineItem, ContPAQiEntry
- Extraction types: BoundingBox, ExtractionField, InvoiceExtraction
- API types: ApiResponse<T>, PaginatedResponse<T>, InvoiceFilters
- Electron types: ElectronAPI interface, Window augmentation
- Utilities: CONFIDENCE_THRESHOLDS, getConfidenceLevel()

This completes T003.3 (React renderer structure)

TDD: 14 tests written first, all passing