### PR TITLE
feat(T003.5.1): add Jest configuration to package.json

### DIFF
--- a/desktop-app/package.json
+++ b/desktop-app/package.json
@@ -39,6 +39,9 @@
     "jest": "^29.7.0",
     "@types/jest": "^29.5.0",
     "ts-jest": "^29.1.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "@testing-library/react": "^14.1.0",
+    "@testing-library/jest-dom": "^6.2.0",
     "eslint": "^8.56.0",
     "@typescript-eslint/eslint-plugin": "^6.16.0",
     "@typescript-eslint/parser": "^6.16.0"
@@ -58,6 +61,54 @@
     "win": {
       "target": "nsis",
       "icon": "assets/icon.ico"
+    }
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "jsdom",
+    "roots": [
+      "<rootDir>/src",
+      "<rootDir>/tests"
+    ],
+    "testMatch": [
+      "**/__tests__/**/*.+(ts|tsx|js)",
+      "**/?(*.)+(spec|test).+(ts|tsx|js)"
+    ],
+    "transform": {
+      "^.+\\.(ts|tsx)$": "ts-jest"
+    },
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/src/$1",
+      "^@main/(.*)$": "<rootDir>/src/main/$1",
+      "^@renderer/(.*)$": "<rootDir>/src/renderer/$1"
+    },
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ],
+    "setupFilesAfterEnv": [
+      "<rootDir>/tests/setup.ts"
+    ],
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx}",
+      "!src/**/*.d.ts",
+      "!src/main/index.ts"
+    ],
+    "coverageDirectory": "<rootDir>/coverage",
+    "coverageThreshold": {
+      "global": {
+        "branches": 70,
+        "functions": 70,
+        "lines": 70,
+        "statements": 70
+      }
+    },
+    "testEnvironmentOptions": {
+      "url": "http://localhost"
     }
   }
 }

--- a/log_files/T003.5.1_Jest_configuration_Log.md
+++ b/log_files/T003.5.1_Jest_configuration_Log.md
@@ -1,0 +1,115 @@
+# Implementation Log: T003.5.1 - Create Jest configuration in package.json
+
+## Task Information
+- **Task ID**: T003.5.1
+- **Task Name**: Create Jest configuration in package.json
+- **Parent Task**: T003.5 - Create test infrastructure
+- **Date**: 2025-12-16
+- **Status**: ✅ Completed
+
+## Implementation Details
+
+### Objective
+Configure Jest for testing the Electron/React desktop application with TypeScript support.
+
+### Changes Made
+
+#### 1. Added Testing Dependencies
+
+New devDependencies added to `desktop-app/package.json`:
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `jest-environment-jsdom` | ^29.7.0 | DOM simulation for React testing |
+| `@testing-library/react` | ^14.1.0 | React component testing utilities |
+| `@testing-library/jest-dom` | ^6.2.0 | Custom DOM matchers for Jest |
+
+#### 2. Jest Configuration Section
+
+Added comprehensive Jest configuration:
+
+```json
+{
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "jsdom",
+    "roots": ["<rootDir>/src", "<rootDir>/tests"],
+    "testMatch": [
+      "**/__tests__/**/*.+(ts|tsx|js)",
+      "**/?(*.)+(spec|test).+(ts|tsx|js)"
+    ],
+    "transform": {
+      "^.+\\.(ts|tsx)$": "ts-jest"
+    },
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/src/$1",
+      "^@main/(.*)$": "<rootDir>/src/main/$1",
+      "^@renderer/(.*)$": "<rootDir>/src/renderer/$1"
+    },
+    "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "node"],
+    "setupFilesAfterEnv": ["<rootDir>/tests/setup.ts"],
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx}",
+      "!src/**/*.d.ts",
+      "!src/main/index.ts"
+    ],
+    "coverageDirectory": "<rootDir>/coverage",
+    "coverageThreshold": {
+      "global": {
+        "branches": 70,
+        "functions": 70,
+        "lines": 70,
+        "statements": 70
+      }
+    },
+    "testEnvironmentOptions": {
+      "url": "http://localhost"
+    }
+  }
+}
+```
+
+### Configuration Explained
+
+| Setting | Value | Purpose |
+|---------|-------|---------|
+| `preset` | ts-jest | TypeScript transformation |
+| `testEnvironment` | jsdom | DOM simulation for React |
+| `roots` | src, tests | Where to find test files |
+| `testMatch` | spec/test patterns | Test file naming convention |
+| `transform` | ts-jest | Compile TypeScript |
+| `moduleNameMapper` | @/* aliases | Match tsconfig paths |
+| `moduleFileExtensions` | ts, tsx, js, jsx | Supported extensions |
+| `setupFilesAfterEnv` | tests/setup.ts | Global test setup |
+| `collectCoverageFrom` | src/**/* | Coverage sources |
+| `coverageThreshold` | 70% | Minimum coverage requirement |
+
+### Test Coverage
+
+17 tests verify:
+- Jest dependencies exist
+- Jest configuration section exists
+- Preset is ts-jest
+- Test environment is jsdom
+- Roots are configured
+- Test file patterns are configured
+- Module path aliases work
+- Coverage settings are present
+- Transform configuration exists
+- Setup files are configured
+
+### Verification Results
+- All 17 tests passed
+- Configuration matches tsconfig.json path aliases
+- Ready for React component testing
+
+## Related Files
+- Configuration: `desktop-app/package.json`
+- Test file: `tests/desktop_app/test_T003_5_1_jest_config.py`
+- Test log: `log_tests/T003.5.1_Jest_configuration_TestLog.md`
+- Learn guide: `log_learn/T003.5.1_Jest_configuration_Guide.md`
+
+## Next Steps
+- T003.5.2: Create desktop-app/tests/unit/ directory
+- T003.5.3: Create desktop-app/tests/e2e/ directory
+- T003.5.4: Create test utilities and mocks

--- a/log_learn/T003.5.1_Jest_configuration_Guide.md
+++ b/log_learn/T003.5.1_Jest_configuration_Guide.md
@@ -1,0 +1,390 @@
+# Learning Guide: T003.5.1 - Create Jest configuration in package.json
+
+## Overview
+
+This guide covers configuring Jest for an Electron/React application with TypeScript support.
+
+## Concepts Covered
+
+### 1. Jest Configuration Options
+
+Jest can be configured in multiple ways:
+
+```javascript
+// Option 1: package.json (recommended for simple projects)
+{
+  "jest": {
+    "preset": "ts-jest"
+  }
+}
+
+// Option 2: jest.config.js (for complex configurations)
+module.exports = {
+  preset: 'ts-jest',
+};
+
+// Option 3: jest.config.ts (TypeScript config)
+import type { Config } from 'jest';
+const config: Config = {
+  preset: 'ts-jest',
+};
+export default config;
+```
+
+### 2. TypeScript Configuration with ts-jest
+
+```json
+{
+  "jest": {
+    "preset": "ts-jest",
+    "transform": {
+      "^.+\\.(ts|tsx)$": "ts-jest"
+    }
+  }
+}
+```
+
+Key settings:
+- **preset**: Use ts-jest for TypeScript support
+- **transform**: Apply ts-jest to .ts and .tsx files
+
+### 3. Test Environment
+
+```json
+{
+  "jest": {
+    "testEnvironment": "jsdom",
+    "testEnvironmentOptions": {
+      "url": "http://localhost"
+    }
+  }
+}
+```
+
+Environments:
+- **node**: For Node.js applications
+- **jsdom**: For DOM/browser testing (React)
+
+### 4. Test File Patterns
+
+```json
+{
+  "jest": {
+    "roots": ["<rootDir>/src", "<rootDir>/tests"],
+    "testMatch": [
+      "**/__tests__/**/*.+(ts|tsx|js)",
+      "**/?(*.)+(spec|test).+(ts|tsx|js)"
+    ]
+  }
+}
+```
+
+Conventions:
+- `__tests__/` directories
+- `*.test.ts` or `*.spec.ts` files
+- `*.test.tsx` for React components
+
+### 5. Module Path Aliases
+
+Match tsconfig.json paths with moduleNameMapper:
+
+```json
+// tsconfig.json
+{
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"],
+      "@main/*": ["./src/main/*"],
+      "@renderer/*": ["./src/renderer/*"]
+    }
+  }
+}
+
+// package.json (Jest)
+{
+  "jest": {
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/src/$1",
+      "^@main/(.*)$": "<rootDir>/src/main/$1",
+      "^@renderer/(.*)$": "<rootDir>/src/renderer/$1"
+    }
+  }
+}
+```
+
+### 6. Coverage Configuration
+
+```json
+{
+  "jest": {
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx}",
+      "!src/**/*.d.ts",
+      "!src/main/index.ts"
+    ],
+    "coverageDirectory": "<rootDir>/coverage",
+    "coverageThreshold": {
+      "global": {
+        "branches": 70,
+        "functions": 70,
+        "lines": 70,
+        "statements": 70
+      }
+    }
+  }
+}
+```
+
+Coverage options:
+- **collectCoverageFrom**: Files to include
+- **coverageDirectory**: Output location
+- **coverageThreshold**: Minimum requirements
+
+## Code Examples
+
+### Complete Jest Configuration
+
+```json
+{
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "jsdom",
+    "roots": [
+      "<rootDir>/src",
+      "<rootDir>/tests"
+    ],
+    "testMatch": [
+      "**/__tests__/**/*.+(ts|tsx|js)",
+      "**/?(*.)+(spec|test).+(ts|tsx|js)"
+    ],
+    "transform": {
+      "^.+\\.(ts|tsx)$": "ts-jest"
+    },
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/src/$1",
+      "^@main/(.*)$": "<rootDir>/src/main/$1",
+      "^@renderer/(.*)$": "<rootDir>/src/renderer/$1"
+    },
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ],
+    "setupFilesAfterEnv": [
+      "<rootDir>/tests/setup.ts"
+    ],
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx}",
+      "!src/**/*.d.ts",
+      "!src/main/index.ts"
+    ],
+    "coverageDirectory": "<rootDir>/coverage",
+    "coverageThreshold": {
+      "global": {
+        "branches": 70,
+        "functions": 70,
+        "lines": 70,
+        "statements": 70
+      }
+    }
+  }
+}
+```
+
+### Test Setup File (tests/setup.ts)
+
+```typescript
+import '@testing-library/jest-dom';
+
+// Global test setup
+beforeAll(() => {
+  // Setup before all tests
+});
+
+afterAll(() => {
+  // Cleanup after all tests
+});
+
+// Mock window.matchMedia
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
+```
+
+### Example React Component Test
+
+```typescript
+// src/renderer/components/Button.test.tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import Button from './Button';
+
+describe('Button', () => {
+  it('renders button with text', () => {
+    render(<Button>Click me</Button>);
+    expect(screen.getByText('Click me')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', () => {
+    const handleClick = jest.fn();
+    render(<Button onClick={handleClick}>Click me</Button>);
+
+    fireEvent.click(screen.getByText('Click me'));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+### Example Unit Test
+
+```typescript
+// src/renderer/utils/format.test.ts
+import { formatCurrency, formatDate } from './format';
+
+describe('formatCurrency', () => {
+  it('formats Mexican peso amounts', () => {
+    expect(formatCurrency(1234.56)).toBe('$1,234.56');
+  });
+
+  it('handles zero', () => {
+    expect(formatCurrency(0)).toBe('$0.00');
+  });
+});
+
+describe('formatDate', () => {
+  it('formats dates in Spanish', () => {
+    const date = new Date('2024-01-15');
+    expect(formatDate(date)).toBe('15 de enero de 2024');
+  });
+});
+```
+
+## Best Practices
+
+### 1. Test File Organization
+
+```
+desktop-app/
+├── src/
+│   └── renderer/
+│       └── components/
+│           ├── Button.tsx
+│           └── Button.test.tsx  // Co-located tests
+├── tests/
+│   ├── setup.ts                 // Global setup
+│   ├── unit/                    // Unit tests
+│   └── e2e/                     // End-to-end tests
+```
+
+### 2. Naming Conventions
+
+```typescript
+// ✅ Good - descriptive test names
+describe('InvoiceForm', () => {
+  it('displays validation error for invalid RFC', () => {});
+  it('submits form when all fields are valid', () => {});
+});
+
+// ❌ Bad - vague test names
+describe('Form', () => {
+  it('works', () => {});
+  it('test 1', () => {});
+});
+```
+
+### 3. Coverage Thresholds
+
+```json
+{
+  "jest": {
+    "coverageThreshold": {
+      "global": {
+        "branches": 70,
+        "functions": 70,
+        "lines": 70,
+        "statements": 70
+      },
+      // Per-file thresholds
+      "./src/renderer/utils/": {
+        "branches": 90,
+        "functions": 90
+      }
+    }
+  }
+}
+```
+
+### 4. Mocking External Dependencies
+
+```typescript
+// Mock electron
+jest.mock('electron', () => ({
+  ipcRenderer: {
+    invoke: jest.fn(),
+    send: jest.fn(),
+    on: jest.fn(),
+  },
+}));
+
+// Mock API calls
+jest.mock('../services/api', () => ({
+  fetchInvoice: jest.fn().mockResolvedValue({ id: '123' }),
+}));
+```
+
+## NPM Scripts
+
+```json
+{
+  "scripts": {
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "test:ci": "jest --ci --coverage --reporters=default --reporters=jest-junit"
+  }
+}
+```
+
+## Required Dependencies
+
+```json
+{
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "@types/jest": "^29.5.0",
+    "ts-jest": "^29.1.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "@testing-library/react": "^14.1.0",
+    "@testing-library/jest-dom": "^6.2.0"
+  }
+}
+```
+
+## Summary
+
+Jest configuration for Electron/React with TypeScript involves:
+1. ✅ Use ts-jest preset for TypeScript support
+2. ✅ Set testEnvironment to jsdom for React testing
+3. ✅ Configure moduleNameMapper to match tsconfig paths
+4. ✅ Set up coverage thresholds for code quality
+5. ✅ Create setup file for global test configuration
+6. ✅ Add testing-library packages for React testing
+
+## References
+
+- [Jest Documentation](https://jestjs.io/docs/getting-started)
+- [ts-jest Documentation](https://kulshekhar.github.io/ts-jest/)
+- [Testing Library - React](https://testing-library.com/docs/react-testing-library/intro)
+- [Jest Configuration Options](https://jestjs.io/docs/configuration)

--- a/log_tests/T003.5.1_Jest_configuration_TestLog.md
+++ b/log_tests/T003.5.1_Jest_configuration_TestLog.md
@@ -1,0 +1,122 @@
+# Test Log: T003.5.1 - Create Jest configuration in package.json
+
+## Test Information
+- **Task ID**: T003.5.1
+- **Test File**: `tests/desktop_app/test_T003_5_1_jest_config.py`
+- **Date**: 2025-12-16
+- **Framework**: pytest 9.0.2
+- **Status**: ✅ All Tests Passed
+
+## Test Results Summary
+
+| Test Name | Status | Duration |
+|-----------|--------|----------|
+| test_jest_dependency_exists | ✅ PASSED | <0.01s |
+| test_ts_jest_dependency_exists | ✅ PASSED | <0.01s |
+| test_jest_types_dependency_exists | ✅ PASSED | <0.01s |
+| test_test_script_exists | ✅ PASSED | <0.01s |
+| test_jest_config_section_exists | ✅ PASSED | <0.01s |
+| test_jest_preset_is_ts_jest | ✅ PASSED | <0.01s |
+| test_jest_test_environment_is_jsdom | ✅ PASSED | <0.01s |
+| test_jest_roots_configured | ✅ PASSED | <0.01s |
+| test_jest_test_match_configured | ✅ PASSED | <0.01s |
+| test_jest_module_name_mapper_configured | ✅ PASSED | <0.01s |
+| test_jest_coverage_directory_configured | ✅ PASSED | <0.01s |
+| test_jest_collect_coverage_from_configured | ✅ PASSED | <0.01s |
+| test_jest_transform_configured | ✅ PASSED | <0.01s |
+| test_jest_setup_files_after_env_configured | ✅ PASSED | <0.01s |
+| test_jest_module_file_extensions_configured | ✅ PASSED | <0.01s |
+| test_jest_test_environment_options | ✅ PASSED | <0.01s |
+| test_jest_coverage_threshold_configured | ✅ PASSED | <0.01s |
+
+**Total**: 17 passed in 0.09s
+
+## Test Approach
+
+### Strategy
+1. Verify Jest dependencies are installed
+2. Verify Jest configuration section exists
+3. Validate each configuration option
+4. Check coverage settings
+5. Verify TypeScript transformation
+
+## Test Cases Description
+
+### Dependency Tests
+
+#### test_jest_dependency_exists
+**Purpose**: Verify Jest is installed
+**Assertion**: "jest" in devDependencies, version ^29.x
+
+#### test_ts_jest_dependency_exists
+**Purpose**: Verify ts-jest is installed
+**Assertion**: "ts-jest" in devDependencies
+
+#### test_jest_types_dependency_exists
+**Purpose**: Verify Jest types are installed
+**Assertion**: "@types/jest" in devDependencies
+
+### Script Tests
+
+#### test_test_script_exists
+**Purpose**: Verify test script is defined
+**Assertion**: "test" script exists and uses "jest"
+
+### Configuration Tests
+
+#### test_jest_config_section_exists
+**Purpose**: Verify Jest config section exists
+**Assertion**: "jest" key in package.json
+
+#### test_jest_preset_is_ts_jest
+**Purpose**: Verify TypeScript preset
+**Assertion**: preset === "ts-jest"
+
+#### test_jest_test_environment_is_jsdom
+**Purpose**: Verify DOM environment
+**Assertion**: testEnvironment === "jsdom"
+
+#### test_jest_roots_configured
+**Purpose**: Verify test roots
+**Assertion**: roots includes "<rootDir>/src"
+
+#### test_jest_test_match_configured
+**Purpose**: Verify test file patterns
+**Assertion**: testMatch includes test/spec patterns with ts/tsx
+
+#### test_jest_module_name_mapper_configured
+**Purpose**: Verify path aliases
+**Assertion**: moduleNameMapper has @ alias mappings
+
+#### test_jest_coverage_directory_configured
+**Purpose**: Verify coverage output directory
+**Assertion**: coverageDirectory is configured
+
+#### test_jest_collect_coverage_from_configured
+**Purpose**: Verify coverage sources
+**Assertion**: collectCoverageFrom includes src directory
+
+#### test_jest_transform_configured
+**Purpose**: Verify TypeScript transformation
+**Assertion**: transform has ts/tsx patterns
+
+#### test_jest_setup_files_after_env_configured
+**Purpose**: Verify setup files
+**Assertion**: setupFilesAfterEnv has at least one entry
+
+#### test_jest_module_file_extensions_configured
+**Purpose**: Verify file extensions
+**Assertion**: includes ts, tsx, js, jsx
+
+#### test_jest_test_environment_options
+**Purpose**: Verify jsdom options (optional)
+**Assertion**: If present, is a dict
+
+#### test_jest_coverage_threshold_configured
+**Purpose**: Verify coverage thresholds (optional)
+**Assertion**: If present, has global thresholds
+
+## Test Command
+```bash
+python -m pytest tests/desktop_app/test_T003_5_1_jest_config.py -v
+```

--- a/specs/001-windows-native-ai/tasks.md
+++ b/specs/001-windows-native-ai/tasks.md
@@ -311,7 +311,15 @@
     - Logs: `log_files/T003.4.5_*`, `log_tests/T003.4.5_*`, `log_learn/T003.4.5_*`
 
 - [ ] **T003.5** [P] Create test infrastructure
-  - [ ] T003.5.1 Create Jest configuration in `package.json`
+  - [x] T003.5.1 Create Jest configuration in `package.json` ✅ *Completed 2025-12-16*
+    - Updated: `desktop-app/package.json` with comprehensive Jest configuration
+    - Preset: ts-jest for TypeScript support
+    - Environment: jsdom for React component testing
+    - Coverage: 70% threshold for branches, functions, lines, statements
+    - Path aliases: @/, @main/, @renderer/ matching tsconfig.json
+    - Added: jest-environment-jsdom, @testing-library/react, @testing-library/jest-dom
+    - Test: `tests/desktop_app/test_T003_5_1_jest_config.py` (17 tests passed)
+    - Logs: `log_files/T003.5.1_*`, `log_tests/T003.5.1_*`, `log_learn/T003.5.1_*`
   - [ ] T003.5.2 Create `desktop-app/tests/unit/` directory
   - [ ] T003.5.3 Create `desktop-app/tests/e2e/` directory
   - [ ] T003.5.4 Create test utilities and mocks

--- a/tests/desktop_app/test_T003_5_1_jest_config.py
+++ b/tests/desktop_app/test_T003_5_1_jest_config.py
@@ -1,0 +1,150 @@
+"""
+Tests for T003.5.1: Create Jest configuration in package.json
+
+Tests verify that Jest is properly configured for the desktop-app
+with TypeScript support, React testing environment, and coverage settings.
+"""
+
+import json
+import os
+
+import pytest
+
+
+# Path to the package.json file
+PACKAGE_JSON_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+    "desktop-app",
+    "package.json",
+)
+
+
+class TestJestConfiguration:
+    """Test suite for Jest configuration in package.json."""
+
+    @pytest.fixture
+    def package_json(self):
+        """Load package.json."""
+        with open(PACKAGE_JSON_PATH, "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    def test_jest_dependency_exists(self, package_json):
+        """Test that jest is in devDependencies."""
+        dev_deps = package_json.get("devDependencies", {})
+        assert "jest" in dev_deps, "Must have jest in devDependencies"
+        assert dev_deps["jest"].startswith("^29"), "Jest should be version 29.x"
+
+    def test_ts_jest_dependency_exists(self, package_json):
+        """Test that ts-jest is in devDependencies."""
+        dev_deps = package_json.get("devDependencies", {})
+        assert "ts-jest" in dev_deps, "Must have ts-jest in devDependencies"
+
+    def test_jest_types_dependency_exists(self, package_json):
+        """Test that @types/jest is in devDependencies."""
+        dev_deps = package_json.get("devDependencies", {})
+        assert "@types/jest" in dev_deps, "Must have @types/jest in devDependencies"
+
+    def test_test_script_exists(self, package_json):
+        """Test that test script is defined."""
+        scripts = package_json.get("scripts", {})
+        assert "test" in scripts, "Must have test script"
+        assert "jest" in scripts["test"], "Test script should use jest"
+
+    def test_jest_config_section_exists(self, package_json):
+        """Test that jest configuration section exists."""
+        assert "jest" in package_json, "package.json must have 'jest' configuration section"
+
+    def test_jest_preset_is_ts_jest(self, package_json):
+        """Test that Jest uses ts-jest preset."""
+        jest_config = package_json.get("jest", {})
+        assert jest_config.get("preset") == "ts-jest", "Jest preset should be 'ts-jest'"
+
+    def test_jest_test_environment_is_jsdom(self, package_json):
+        """Test that Jest uses jsdom for React testing."""
+        jest_config = package_json.get("jest", {})
+        assert jest_config.get("testEnvironment") == "jsdom", "Jest testEnvironment should be 'jsdom'"
+
+    def test_jest_roots_configured(self, package_json):
+        """Test that Jest roots are configured."""
+        jest_config = package_json.get("jest", {})
+        assert "roots" in jest_config, "Jest must have roots configured"
+        roots = jest_config["roots"]
+        assert "<rootDir>/src" in roots, "Roots should include <rootDir>/src"
+
+    def test_jest_test_match_configured(self, package_json):
+        """Test that Jest testMatch is configured."""
+        jest_config = package_json.get("jest", {})
+        assert "testMatch" in jest_config, "Jest must have testMatch configured"
+        test_match = jest_config["testMatch"]
+        # Should match test/spec files with ts/tsx extensions
+        # Patterns like "**/?(*.)+(spec|test).+(ts|tsx|js)" or similar
+        assert any(
+            ("test" in pattern and "ts" in pattern) or
+            ("spec" in pattern and "ts" in pattern) or
+            "__tests__" in pattern
+            for pattern in test_match
+        ), "testMatch should include TypeScript test files"
+
+    def test_jest_module_name_mapper_configured(self, package_json):
+        """Test that Jest moduleNameMapper is configured for path aliases."""
+        jest_config = package_json.get("jest", {})
+        assert "moduleNameMapper" in jest_config, "Jest must have moduleNameMapper for path aliases"
+        mapper = jest_config["moduleNameMapper"]
+        # Should have @ alias mapping
+        assert any("@" in key for key in mapper.keys()), "Should have @ path alias mapping"
+
+    def test_jest_coverage_directory_configured(self, package_json):
+        """Test that Jest coverageDirectory is configured."""
+        jest_config = package_json.get("jest", {})
+        assert "coverageDirectory" in jest_config, "Jest must have coverageDirectory configured"
+
+    def test_jest_collect_coverage_from_configured(self, package_json):
+        """Test that Jest collectCoverageFrom is configured."""
+        jest_config = package_json.get("jest", {})
+        assert "collectCoverageFrom" in jest_config, "Jest must have collectCoverageFrom configured"
+        coverage_from = jest_config["collectCoverageFrom"]
+        # Should include src files
+        assert any("src" in pattern for pattern in coverage_from), \
+            "collectCoverageFrom should include src directory"
+
+    def test_jest_transform_configured(self, package_json):
+        """Test that Jest transform is configured for TypeScript."""
+        jest_config = package_json.get("jest", {})
+        assert "transform" in jest_config, "Jest must have transform configured"
+        transform = jest_config["transform"]
+        # Should transform .ts and .tsx files
+        ts_patterns = [key for key in transform.keys() if "ts" in key]
+        assert len(ts_patterns) > 0, "Transform should include TypeScript patterns"
+
+    def test_jest_setup_files_after_env_configured(self, package_json):
+        """Test that Jest setupFilesAfterEnv is configured."""
+        jest_config = package_json.get("jest", {})
+        assert "setupFilesAfterEnv" in jest_config, "Jest must have setupFilesAfterEnv configured"
+        setup_files = jest_config["setupFilesAfterEnv"]
+        assert len(setup_files) > 0, "Should have at least one setup file"
+
+    def test_jest_module_file_extensions_configured(self, package_json):
+        """Test that Jest moduleFileExtensions includes TypeScript."""
+        jest_config = package_json.get("jest", {})
+        assert "moduleFileExtensions" in jest_config, "Jest must have moduleFileExtensions"
+        extensions = jest_config["moduleFileExtensions"]
+        assert "ts" in extensions, "Should include .ts extension"
+        assert "tsx" in extensions, "Should include .tsx extension"
+        assert "js" in extensions, "Should include .js extension"
+        assert "jsx" in extensions, "Should include .jsx extension"
+
+    def test_jest_test_environment_options(self, package_json):
+        """Test that Jest has testEnvironmentOptions for jsdom."""
+        jest_config = package_json.get("jest", {})
+        # testEnvironmentOptions is optional but good to have for jsdom
+        if "testEnvironmentOptions" in jest_config:
+            options = jest_config["testEnvironmentOptions"]
+            assert isinstance(options, dict), "testEnvironmentOptions should be a dict"
+
+    def test_jest_coverage_threshold_configured(self, package_json):
+        """Test that Jest has coverage thresholds (optional but recommended)."""
+        jest_config = package_json.get("jest", {})
+        # Coverage thresholds are optional but good practice
+        if "coverageThreshold" in jest_config:
+            threshold = jest_config["coverageThreshold"]
+            assert "global" in threshold, "Should have global coverage threshold"


### PR DESCRIPTION
Added comprehensive Jest configuration for Electron/React testing:
- Preset: ts-jest for TypeScript transformation
- Environment: jsdom for React component testing
- Path aliases: @/, @main/, @renderer/ matching tsconfig.json
- Coverage: 70% threshold for branches, functions, lines, statements
- Setup: tests/setup.ts for global test configuration

Added new testing dependencies:
- jest-environment-jsdom ^29.7.0
- @testing-library/react ^14.1.0
- @testing-library/jest-dom ^6.2.0

Added 17 tests to verify Jest configuration completeness.