### PR TITLE
feat(T004.2.2): configure Kestrel to bind to localhost:5000

### DIFF
--- a/log_files/T004.2.2_Kestrel_binding_Log.md
+++ b/log_files/T004.2.2_Kestrel_binding_Log.md
@@ -1,0 +1,72 @@
+# T004.2.2 Implementation Log: Configure Kestrel Binding
+
+## Task Overview
+- **Task ID**: T004.2.2
+- **Task Name**: Configure Kestrel to bind only to 127.0.0.1:5000
+- **Status**: Completed
+- **Date**: 2025-12-16
+
+## Implementation Details
+
+### Configuration Added
+Added Kestrel server configuration in Program.cs:
+
+```csharp
+// Configure Kestrel to bind only to localhost:5000
+// This ensures the service is only accessible from the local machine
+builder.WebHost.ConfigureKestrel(options =>
+{
+    options.ListenLocalhost(5000); // HTTP only - localhost service
+});
+```
+
+### Key Configuration Choices
+
+1. **ListenLocalhost(5000)**
+   - Binds exclusively to 127.0.0.1:5000
+   - Not accessible from external network
+   - Uses HTTP (not HTTPS) for localhost-only service
+
+2. **No HTTPS**
+   - Service runs only on localhost
+   - No certificate needed
+   - Simpler configuration
+   - Security provided by OS firewall
+
+3. **Port 5000**
+   - Standard ASP.NET Core development port
+   - Different from AI service (8000)
+   - Easy to remember
+
+### Security Implications
+
+| Aspect | Configuration | Reason |
+|--------|---------------|--------|
+| Binding | 127.0.0.1 only | Not accessible from network |
+| Protocol | HTTP | Localhost traffic is secure |
+| Authentication | None | Local service, trusted caller |
+| Authorization | None | Desktop app is only client |
+
+### Why Localhost-Only?
+
+The Windows Bridge service:
+1. **Called only by desktop app** on same machine
+2. **Interfaces with ContPAQi SDK** which is local
+3. **No external API exposure** needed
+4. **Maximum security** through network isolation
+
+### Configuration Location
+
+The Kestrel configuration is placed:
+- After `WebApplication.CreateBuilder(args)`
+- Before service configuration
+- Before Serilog configuration
+
+This ensures the web host is configured before any services are added.
+
+## Files Changed
+- Modified: `windows-bridge/src/ContPAQWinBridge/Program.cs`
+
+## Testing
+- 9 tests in `tests/windows_bridge/test_T004_2_2_kestrel_binding.py`
+- All tests passed

--- a/log_learn/T004.2.2_Kestrel_binding_Guide.md
+++ b/log_learn/T004.2.2_Kestrel_binding_Guide.md
@@ -1,0 +1,244 @@
+# T004.2.2 Learning Guide: Kestrel Server Configuration
+
+## Overview
+Kestrel is the cross-platform web server for ASP.NET Core. This guide explains how to configure Kestrel to bind to specific addresses and ports.
+
+## What is Kestrel?
+
+Kestrel is:
+- The default web server for ASP.NET Core
+- Cross-platform (Windows, Linux, macOS)
+- High-performance
+- Supports HTTP/1.1, HTTP/2, and HTTP/3
+- Can run standalone or behind a reverse proxy
+
+## Configuration Methods
+
+### 1. ConfigureKestrel (Programmatic)
+```csharp
+builder.WebHost.ConfigureKestrel(options =>
+{
+    options.ListenLocalhost(5000);
+});
+```
+
+### 2. UseUrls (Simple)
+```csharp
+builder.WebHost.UseUrls("http://127.0.0.1:5000");
+```
+
+### 3. appsettings.json
+```json
+{
+  "Kestrel": {
+    "Endpoints": {
+      "Http": {
+        "Url": "http://127.0.0.1:5000"
+      }
+    }
+  }
+}
+```
+
+### 4. Command Line
+```bash
+dotnet run --urls "http://127.0.0.1:5000"
+```
+
+### 5. Environment Variable
+```bash
+ASPNETCORE_URLS=http://127.0.0.1:5000
+```
+
+## Listen Methods
+
+### ListenLocalhost
+```csharp
+options.ListenLocalhost(5000); // HTTP on 127.0.0.1:5000
+options.ListenLocalhost(5001, opts => opts.UseHttps()); // HTTPS
+```
+
+Binds to IPv4 127.0.0.1 and IPv6 ::1 (loopback only).
+
+### Listen (Specific IP)
+```csharp
+options.Listen(IPAddress.Loopback, 5000); // IPv4 loopback
+options.Listen(IPAddress.IPv6Loopback, 5000); // IPv6 loopback
+options.Listen(IPAddress.Parse("192.168.1.100"), 5000); // Specific IP
+```
+
+### ListenAnyIP (All Interfaces)
+```csharp
+options.ListenAnyIP(5000); // Binds to 0.0.0.0 (all IPv4) and :: (all IPv6)
+```
+
+⚠️ **Warning**: This exposes the service to the network!
+
+## Binding Scenarios
+
+### Localhost Only (Recommended for Internal Services)
+```csharp
+builder.WebHost.ConfigureKestrel(options =>
+{
+    options.ListenLocalhost(5000);
+});
+```
+
+### Multiple Endpoints
+```csharp
+builder.WebHost.ConfigureKestrel(options =>
+{
+    options.ListenLocalhost(5000); // HTTP
+    options.ListenLocalhost(5001, opts => opts.UseHttps()); // HTTPS
+});
+```
+
+### All Interfaces (Public Service)
+```csharp
+builder.WebHost.ConfigureKestrel(options =>
+{
+    options.ListenAnyIP(80);
+    options.ListenAnyIP(443, opts => opts.UseHttps());
+});
+```
+
+## HTTPS Configuration
+
+### Development Certificate
+```csharp
+options.ListenLocalhost(5001, opts =>
+{
+    opts.UseHttps(); // Uses development certificate
+});
+```
+
+### Custom Certificate
+```csharp
+options.ListenLocalhost(5001, opts =>
+{
+    opts.UseHttps("certificate.pfx", "password");
+});
+```
+
+### Certificate from Store
+```csharp
+options.ListenAnyIP(443, opts =>
+{
+    opts.UseHttps(httpsOptions =>
+    {
+        httpsOptions.ServerCertificateSelector = (connectionContext, name) =>
+        {
+            // Return certificate based on SNI
+            return GetCertificate(name);
+        };
+    });
+});
+```
+
+## Security Considerations
+
+### Why Localhost Only?
+
+| Scenario | Binding | Security |
+|----------|---------|----------|
+| Internal service | `ListenLocalhost` | ✅ Best - Network isolated |
+| Behind proxy | `ListenLocalhost` | ✅ Good - Proxy handles external |
+| Direct public | `ListenAnyIP` | ⚠️ Requires auth/TLS |
+
+### Common Mistakes
+
+❌ **Bad: Binding to all interfaces without security**
+```csharp
+options.ListenAnyIP(5000); // Exposed to network without HTTPS!
+```
+
+✅ **Good: Localhost for internal services**
+```csharp
+options.ListenLocalhost(5000); // Safe - localhost only
+```
+
+✅ **Good: All interfaces with HTTPS for public**
+```csharp
+options.ListenAnyIP(443, opts => opts.UseHttps());
+```
+
+## Server Limits Configuration
+
+```csharp
+builder.WebHost.ConfigureKestrel(options =>
+{
+    options.ListenLocalhost(5000);
+
+    // Connection limits
+    options.Limits.MaxConcurrentConnections = 100;
+    options.Limits.MaxConcurrentUpgradedConnections = 100;
+
+    // Request limits
+    options.Limits.MaxRequestBodySize = 10 * 1024 * 1024; // 10 MB
+    options.Limits.MaxRequestHeaderCount = 100;
+
+    // Timeouts
+    options.Limits.KeepAliveTimeout = TimeSpan.FromMinutes(2);
+    options.Limits.RequestHeadersTimeout = TimeSpan.FromSeconds(30);
+});
+```
+
+## Configuration Order
+
+The configuration is evaluated in this order (later overrides earlier):
+1. Default values
+2. ConfigureKestrel in code
+3. appsettings.json
+4. Environment variables
+5. Command line arguments
+
+## ContPAQWinBridge Configuration
+
+For the Windows Bridge service:
+
+```csharp
+// Configure Kestrel to bind only to localhost:5000
+builder.WebHost.ConfigureKestrel(options =>
+{
+    options.ListenLocalhost(5000); // HTTP only - localhost service
+});
+```
+
+### Why This Configuration?
+
+1. **ListenLocalhost** - Only accessible from local machine
+2. **Port 5000** - Standard ASP.NET Core port
+3. **HTTP only** - No certificate needed for localhost
+4. **No network exposure** - Maximum security
+
+## Debugging Binding Issues
+
+### Check Active Bindings
+```csharp
+var urls = app.Urls;
+foreach (var url in urls)
+{
+    Log.Information("Listening on: {Url}", url);
+}
+```
+
+### Common Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| Address already in use | Port occupied | Use different port |
+| Permission denied | Port < 1024 on Linux | Use port > 1024 or run as root |
+| Cannot bind to address | Invalid IP | Check IP is available |
+
+## Key Takeaways
+
+1. **ListenLocalhost** for internal services
+2. **ListenAnyIP** only for public services with HTTPS
+3. **Configuration hierarchy** allows flexible override
+4. **Port 5000** is convention for ASP.NET Core development
+5. **Security first** - bind to minimum required interfaces
+
+## References
+- [Kestrel Configuration](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/endpoints)
+- [HTTPS Configuration](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/https)
+- [Server Limits](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/options)

--- a/log_tests/T004.2.2_Kestrel_binding_TestLog.md
+++ b/log_tests/T004.2.2_Kestrel_binding_TestLog.md
@@ -1,0 +1,65 @@
+# T004.2.2 Test Log: Configure Kestrel Binding
+
+## Test Overview
+- **Task ID**: T004.2.2
+- **Test File**: `tests/windows_bridge/test_T004_2_2_kestrel_binding.py`
+- **Total Tests**: 9
+- **Passed**: 9
+- **Failed**: 0
+- **Date**: 2025-12-16
+
+## Test Execution Results
+
+```
+============================= test session starts ==============================
+platform linux -- Python 3.11.14, pytest-9.0.2, pluggy-1.6.0
+
+tests/windows_bridge/test_T004_2_2_kestrel_binding.py::TestKestrelConfiguration::test_configures_kestrel PASSED
+tests/windows_bridge/test_T004_2_2_kestrel_binding.py::TestKestrelConfiguration::test_binds_to_localhost PASSED
+tests/windows_bridge/test_T004_2_2_kestrel_binding.py::TestKestrelConfiguration::test_binds_to_port_5000 PASSED
+tests/windows_bridge/test_T004_2_2_kestrel_binding.py::TestKestrelConfiguration::test_uses_http_not_https PASSED
+tests/windows_bridge/test_T004_2_2_kestrel_binding.py::TestSecurityConfiguration::test_no_external_binding PASSED
+tests/windows_bridge/test_T004_2_2_kestrel_binding.py::TestSecurityConfiguration::test_localhost_only_comment PASSED
+tests/windows_bridge/test_T004_2_2_kestrel_binding.py::TestUrlConfiguration::test_has_url_configuration PASSED
+tests/windows_bridge/test_T004_2_2_kestrel_binding.py::TestUrlConfiguration::test_complete_url_present PASSED
+tests/windows_bridge/test_T004_2_2_kestrel_binding.py::TestKestrelOptions::test_uses_webhost_or_kestrel_options PASSED
+
+============================== 9 passed in 0.04s ===============================
+```
+
+## Test Categories
+
+### TestKestrelConfiguration (4 tests)
+| Test | Description | Status |
+|------|-------------|--------|
+| test_configures_kestrel | Has Kestrel configuration | PASSED |
+| test_binds_to_localhost | Binds to 127.0.0.1/localhost | PASSED |
+| test_binds_to_port_5000 | Uses port 5000 | PASSED |
+| test_uses_http_not_https | Uses HTTP for localhost | PASSED |
+
+### TestSecurityConfiguration (2 tests)
+| Test | Description | Status |
+|------|-------------|--------|
+| test_no_external_binding | No 0.0.0.0 or * binding | PASSED |
+| test_localhost_only_comment | Documents localhost design | PASSED |
+
+### TestUrlConfiguration (2 tests)
+| Test | Description | Status |
+|------|-------------|--------|
+| test_has_url_configuration | Has URL configuration | PASSED |
+| test_complete_url_present | Has complete URL pattern | PASSED |
+
+### TestKestrelOptions (1 test)
+| Test | Description | Status |
+|------|-------------|--------|
+| test_uses_webhost_or_kestrel_options | Uses WebHost config | PASSED |
+
+## TDD Workflow
+1. **RED**: 6 tests failed - no Kestrel configuration
+2. **GREEN**: Added ConfigureKestrel with ListenLocalhost(5000) - all 9 tests pass
+3. **REFACTOR**: No refactoring needed
+
+## Notes
+- Tests check for multiple patterns (ConfigureKestrel, UseKestrel, etc.)
+- Security tests verify no accidental external binding
+- ListenLocalhost is the preferred method for localhost-only services

--- a/specs/001-windows-native-ai/tasks.md
+++ b/specs/001-windows-native-ai/tasks.md
@@ -388,7 +388,12 @@
     - Error handling: try-catch-finally with Log.Fatal and Log.CloseAndFlush()
     - Test: `tests/windows_bridge/test_T004_2_1_program_cs.py` (17 tests passed)
     - Logs: `log_files/T004.2.1_*`, `log_tests/T004.2.1_*`, `log_learn/T004.2.1_*`
-  - [ ] T004.2.2 Configure Kestrel to bind only to 127.0.0.1:5000
+  - [x] T004.2.2 Configure Kestrel to bind only to 127.0.0.1:5000 ✅ *Completed 2025-12-16*
+    - Added: builder.WebHost.ConfigureKestrel() with ListenLocalhost(5000)
+    - Security: Binds exclusively to localhost - not accessible from network
+    - Protocol: HTTP only (no HTTPS needed for localhost-only service)
+    - Test: `tests/windows_bridge/test_T004_2_2_kestrel_binding.py` (9 tests passed)
+    - Logs: `log_files/T004.2.2_*`, `log_tests/T004.2.2_*`, `log_learn/T004.2.2_*`
   - [ ] T004.2.3 Create `windows-bridge/src/ContPAQWinBridge/appsettings.json`
   - [ ] T004.2.4 Configure dependency injection container
 

--- a/tests/windows_bridge/test_T004_2_2_kestrel_binding.py
+++ b/tests/windows_bridge/test_T004_2_2_kestrel_binding.py
@@ -1,0 +1,151 @@
+"""
+Tests for T004.2.2: Configure Kestrel to bind only to 127.0.0.1:5000
+
+Verifies that Kestrel is configured to bind exclusively to localhost (127.0.0.1)
+on port 5000, ensuring the service is not accessible from external networks.
+"""
+
+import os
+import re
+import pytest
+
+# Path to the Program.cs file
+PROGRAM_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+    "windows-bridge",
+    "src",
+    "ContPAQWinBridge",
+    "Program.cs"
+)
+
+
+class TestKestrelConfiguration:
+    """Tests for Kestrel server configuration."""
+
+    @pytest.fixture
+    def program_content(self):
+        """Load Program.cs content."""
+        with open(PROGRAM_PATH, "r", encoding="utf-8") as f:
+            return f.read()
+
+    def test_configures_kestrel(self, program_content):
+        """T004.2.2: Should configure Kestrel server."""
+        has_kestrel_config = (
+            "ConfigureKestrel" in program_content or
+            "UseKestrel" in program_content or
+            "Kestrel" in program_content or
+            "builder.WebHost" in program_content
+        )
+        assert has_kestrel_config, "Should configure Kestrel server"
+
+    def test_binds_to_localhost(self, program_content):
+        """T004.2.2: Should bind to localhost (127.0.0.1)."""
+        has_localhost = (
+            "127.0.0.1" in program_content or
+            "localhost" in program_content.lower() or
+            "IPAddress.Loopback" in program_content
+        )
+        assert has_localhost, "Should bind to localhost (127.0.0.1)"
+
+    def test_binds_to_port_5000(self, program_content):
+        """T004.2.2: Should bind to port 5000."""
+        assert "5000" in program_content, "Should bind to port 5000"
+
+    def test_uses_http_not_https(self, program_content):
+        """T004.2.2: Should use HTTP for localhost-only service."""
+        # Either explicitly uses http:// or configures ListenLocalhost
+        has_http = (
+            "http://" in program_content or
+            "ListenLocalhost" in program_content or
+            ("127.0.0.1" in program_content and "5000" in program_content)
+        )
+        assert has_http, "Should use HTTP for localhost-only service"
+
+
+class TestSecurityConfiguration:
+    """Tests for security-related configuration."""
+
+    @pytest.fixture
+    def program_content(self):
+        """Load Program.cs content."""
+        with open(PROGRAM_PATH, "r", encoding="utf-8") as f:
+            return f.read()
+
+    def test_no_external_binding(self, program_content):
+        """T004.2.2: Should not bind to all interfaces (0.0.0.0 or *)."""
+        # Check that we're not accidentally binding to all interfaces
+        binds_all = (
+            "0.0.0.0" in program_content or
+            '"*"' in program_content or
+            "IPAddress.Any" in program_content
+        )
+        # If binding to all, this test fails
+        assert not binds_all or "127.0.0.1" in program_content, \
+            "Should not bind to all interfaces without explicit localhost"
+
+    def test_localhost_only_comment(self, program_content):
+        """T004.2.2: Should have comment explaining localhost-only design."""
+        content_lower = program_content.lower()
+        has_comment = (
+            "localhost" in content_lower or
+            "local" in content_lower or
+            "127.0.0.1" in content_lower
+        )
+        assert has_comment, "Should document localhost-only configuration"
+
+
+class TestUrlConfiguration:
+    """Tests for URL configuration."""
+
+    @pytest.fixture
+    def program_content(self):
+        """Load Program.cs content."""
+        with open(PROGRAM_PATH, "r", encoding="utf-8") as f:
+            return f.read()
+
+    def test_has_url_configuration(self, program_content):
+        """T004.2.2: Should configure URLs explicitly."""
+        has_url_config = (
+            "Urls" in program_content or
+            "urls" in program_content or
+            "Listen" in program_content or
+            "http://127.0.0.1:5000" in program_content or
+            "http://localhost:5000" in program_content
+        )
+        assert has_url_config, "Should configure URLs explicitly"
+
+    def test_complete_url_present(self, program_content):
+        """T004.2.2: Should have complete URL with protocol, host, and port."""
+        # Check for complete URL pattern
+        has_complete_url = (
+            "http://127.0.0.1:5000" in program_content or
+            "http://localhost:5000" in program_content or
+            re.search(r'Listen.*127\.0\.0\.1.*5000', program_content) or
+            re.search(r'ListenLocalhost\s*\(\s*5000', program_content)
+        )
+        assert has_complete_url, "Should have complete URL (http://127.0.0.1:5000)"
+
+
+class TestKestrelOptions:
+    """Tests for Kestrel options configuration."""
+
+    @pytest.fixture
+    def program_content(self):
+        """Load Program.cs content."""
+        with open(PROGRAM_PATH, "r", encoding="utf-8") as f:
+            return f.read()
+
+    def test_uses_webhost_or_kestrel_options(self, program_content):
+        """T004.2.2: Should use WebHost or Kestrel options for configuration."""
+        has_config = (
+            "builder.WebHost" in program_content or
+            "ConfigureKestrel" in program_content or
+            "UseKestrel" in program_content or
+            "UseUrls" in program_content or
+            'Urls' in program_content
+        )
+        assert has_config, "Should use WebHost or Kestrel options"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/windows-bridge/src/ContPAQWinBridge/Program.cs
+++ b/windows-bridge/src/ContPAQWinBridge/Program.cs
@@ -10,6 +10,13 @@ try
 {
     var builder = WebApplication.CreateBuilder(args);
 
+    // Configure Kestrel to bind only to localhost:5000
+    // This ensures the service is only accessible from the local machine
+    builder.WebHost.ConfigureKestrel(options =>
+    {
+        options.ListenLocalhost(5000); // HTTP only - localhost service
+    });
+
     // Configure Serilog
     builder.Host.UseSerilog((context, services, configuration) => configuration
         .ReadFrom.Configuration(context.Configuration)


### PR DESCRIPTION
- Add ConfigureKestrel with ListenLocalhost(5000)
- Bind exclusively to 127.0.0.1 - not accessible from network
- Use HTTP only (no HTTPS for localhost-only service)
- Add security documentation comments

All 9 tests passing.