### PR TITLE
feat(T008.1.3): implement startAIService with real process spawning

### DIFF
--- a/desktop-app/src/main/process-manager.ts
+++ b/desktop-app/src/main/process-manager.ts
@@ -64,6 +64,16 @@ export interface ProcessManagerConfig {
   healthCheckInterval: number;
   maxRestartAttempts: number;
   restartBackoffMs: number;
+  startupTimeoutMs: number;  // T008.1.3: Timeout for process startup
+}
+
+/**
+ * Log entry for process output
+ */
+export interface ProcessLogEntry {
+  timestamp: Date;
+  level: 'stdout' | 'stderr';
+  message: string;
 }
 
 /**
@@ -75,6 +85,7 @@ const DEFAULT_CONFIG: ProcessManagerConfig = {
   healthCheckInterval: 5000,
   maxRestartAttempts: 3,
   restartBackoffMs: 1000,
+  startupTimeoutMs: 30000,  // T008.1.3: 30 second default timeout
 };
 
 /**
@@ -103,6 +114,11 @@ export class ProcessManager {
   // T008.1.2: Start time tracking for uptime
   private aiStartTime: Date | null = null;
   private bridgeStartTime: Date | null = null;
+
+  // T008.1.3: Process logs
+  private aiProcessLogs: ProcessLogEntry[] = [];
+  private bridgeProcessLogs: ProcessLogEntry[] = [];
+  private readonly MAX_LOG_ENTRIES = 1000;
 
   constructor(config: Partial<ProcessManagerConfig> = {}) {
     this.config = { ...DEFAULT_CONFIG, ...config };
@@ -273,6 +289,61 @@ export class ProcessManager {
   }
 
   // ===========================================
+  // T008.1.3: Process Logging Methods
+  // ===========================================
+
+  /**
+   * Get process logs for a service
+   * @param service - Service to get logs for
+   * @returns Array of log entries
+   */
+  getProcessLogs(service: 'ai' | 'bridge'): ProcessLogEntry[] {
+    const logs = service === 'ai' ? this.aiProcessLogs : this.bridgeProcessLogs;
+    return [...logs]; // Return copy
+  }
+
+  /**
+   * Add a log entry for a service
+   * @param service - Service to add log for
+   * @param level - Log level (stdout or stderr)
+   * @param message - Log message
+   */
+  private addLog(service: 'ai' | 'bridge', level: 'stdout' | 'stderr', message: string): void {
+    const logs = service === 'ai' ? this.aiProcessLogs : this.bridgeProcessLogs;
+    const entry: ProcessLogEntry = {
+      timestamp: new Date(),
+      level,
+      message,
+    };
+
+    logs.push(entry);
+
+    // Trim logs if exceeding max
+    if (logs.length > this.MAX_LOG_ENTRIES) {
+      logs.shift();
+    }
+
+    // Also log to console
+    if (level === 'stdout') {
+      console.log(`[AI Service] ${message}`);
+    } else {
+      console.error(`[AI Service ERROR] ${message}`);
+    }
+  }
+
+  /**
+   * Clear process logs for a service
+   * @param service - Service to clear logs for
+   */
+  clearProcessLogs(service: 'ai' | 'bridge'): void {
+    if (service === 'ai') {
+      this.aiProcessLogs = [];
+    } else {
+      this.bridgeProcessLogs = [];
+    }
+  }
+
+  // ===========================================
   // T008.1.2: Status Change Helper
   // ===========================================
 
@@ -324,14 +395,109 @@ export class ProcessManager {
     this.updateStatus('ai', ServiceStatus.STARTING);
     console.log('Starting AI Service...');
 
-    // TODO: Implement actual process spawning in T008.1.3
-    // This is a stub that simulates successful start
-    return new Promise((resolve) => {
-      setTimeout(() => {
+    return new Promise((resolve, reject) => {
+      // T008.1.3: Real process spawning implementation
+      const pythonPath = this.getPythonPath();
+      const aiServicePath = this.getAIServicePath();
+      const srcPath = path.join(aiServicePath, 'src');
+
+      const args = [
+        '-m', 'uvicorn',
+        'main:app',
+        '--host', '127.0.0.1',
+        '--port', String(this.config.aiServicePort),
+      ];
+
+      const spawnOptions = {
+        cwd: srcPath,
+        shell: false,
+        stdio: ['ignore', 'pipe', 'pipe'] as const,
+      };
+
+      // Spawn the process
+      this.aiServiceProcess = spawn(pythonPath, args, spawnOptions);
+
+      // Setup timeout
+      const timeoutId = setTimeout(() => {
+        if (this.aiServiceStatus === ServiceStatus.STARTING) {
+          const error = new Error(`AI Service startup timeout after ${this.config.startupTimeoutMs}ms`);
+          this.setError('ai', error.message);
+          this.updateStatus('ai', ServiceStatus.ERROR);
+          this.emitError('ai', error);
+          reject(error);
+        }
+      }, this.config.startupTimeoutMs);
+
+      // Handle spawn event (process started successfully)
+      this.aiServiceProcess.on('spawn', () => {
+        clearTimeout(timeoutId);
         this.updateStatus('ai', ServiceStatus.RUNNING);
-        console.log('AI Service started (stub)');
+        console.log(`AI Service started (PID: ${this.aiServiceProcess?.pid})`);
         resolve();
-      }, 100);
+      });
+
+      // Handle error event (failed to spawn)
+      this.aiServiceProcess.on('error', (error: Error) => {
+        clearTimeout(timeoutId);
+        this.setError('ai', error.message);
+        this.updateStatus('ai', ServiceStatus.ERROR);
+        this.emitError('ai', error);
+        reject(error);
+      });
+
+      // Handle exit event (process terminated)
+      this.aiServiceProcess.on('exit', (code: number | null, signal: string | null) => {
+        clearTimeout(timeoutId);
+
+        if (this.aiServiceStatus === ServiceStatus.STOPPING) {
+          // Normal shutdown
+          this.updateStatus('ai', ServiceStatus.STOPPED);
+        } else if (code !== 0) {
+          // Abnormal exit
+          const errorMsg = `AI Service exited with code ${code}${signal ? ` (signal: ${signal})` : ''}`;
+          this.setError('ai', errorMsg);
+          this.updateStatus('ai', ServiceStatus.ERROR);
+        } else {
+          // Clean exit while running (unexpected)
+          this.updateStatus('ai', ServiceStatus.STOPPED);
+        }
+
+        this.aiServiceProcess = null;
+      });
+
+      // Capture stdout
+      if (this.aiServiceProcess.stdout) {
+        this.aiServiceProcess.stdout.on('data', (data: Buffer) => {
+          const message = data.toString().trim();
+          if (message) {
+            this.addLog('ai', 'stdout', message);
+          }
+        });
+      }
+
+      // Capture stderr
+      if (this.aiServiceProcess.stderr) {
+        this.aiServiceProcess.stderr.on('data', (data: Buffer) => {
+          const message = data.toString().trim();
+          if (message) {
+            this.addLog('ai', 'stderr', message);
+          }
+        });
+      }
+    });
+  }
+
+  /**
+   * Emit error event
+   * @param service - Service that errored
+   * @param error - Error object
+   */
+  private emitError(service: 'ai' | 'bridge', error: Error): void {
+    this.emit('error', {
+      service,
+      status: ServiceStatus.ERROR,
+      previousStatus: ServiceStatus.STARTING,
+      timestamp: new Date(),
     });
   }
 

--- a/desktop-app/tests/main/process-manager.test.ts
+++ b/desktop-app/tests/main/process-manager.test.ts
@@ -3,6 +3,7 @@
  *
  * T008.1.1: Tests for process start/stop functionality
  * T008.1.2: Tests for ProcessManager infrastructure (events, paths, errors)
+ * T008.1.3: Tests for startAIService process spawning
  *
  * Tests the ProcessManager class which handles lifecycle management
  * of external service processes (AI Service, Windows Bridge).
@@ -14,6 +15,29 @@ import ProcessManager, {
   ProcessManagerConfig,
   processManager,
 } from '@main/process-manager';
+import { EventEmitter } from 'events';
+import { spawn } from 'child_process';
+
+// Create mock process factory for T008.1.3 tests
+function createMockChildProcess() {
+  const mockProcess = new EventEmitter() as EventEmitter & {
+    pid: number;
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: jest.Mock;
+    killed: boolean;
+  };
+  mockProcess.pid = 12345;
+  mockProcess.stdout = new EventEmitter();
+  mockProcess.stderr = new EventEmitter();
+  mockProcess.kill = jest.fn().mockImplementation(() => {
+    mockProcess.killed = true;
+    mockProcess.emit('exit', 0, null);
+    return true;
+  });
+  mockProcess.killed = false;
+  return mockProcess;
+}
 
 // Mock child_process module
 jest.mock('child_process', () => ({
@@ -32,10 +56,19 @@ jest.mock('electron', () => ({
 
 describe('ProcessManager', () => {
   let manager: ProcessManager;
+  let mockProcess: ReturnType<typeof createMockChildProcess>;
+  const mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
 
   beforeEach(() => {
-    manager = new ProcessManager();
     jest.clearAllMocks();
+    // Setup mock process for all tests
+    mockProcess = createMockChildProcess();
+    // Auto-emit spawn event after a short delay to simulate successful start
+    mockSpawn.mockImplementation(() => {
+      setTimeout(() => mockProcess.emit('spawn'), 10);
+      return mockProcess as never;
+    });
+    manager = new ProcessManager();
   });
 
   // ===========================================
@@ -726,5 +759,315 @@ describe('ProcessManager Infrastructure (T008.1.2)', () => {
       manager.resetRestartCount('ai');
       expect(manager.getRestartCount('ai')).toBe(0);
     });
+  });
+});
+
+// ===========================================
+// T008.1.3 - startAIService Process Spawning Tests
+// ===========================================
+
+describe('ProcessManager startAIService Spawning (T008.1.3)', () => {
+  let manager: ProcessManager;
+  let mockProcess: ReturnType<typeof createMockChildProcess>;
+  const mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
+
+  beforeEach(() => {
+    manager = new ProcessManager();
+    mockProcess = createMockChildProcess();
+    mockSpawn.mockReturnValue(mockProcess as never);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // Clean up any pending timers
+    jest.clearAllTimers();
+  });
+
+  // ===========================================
+  // T008.1.3.1 - Locate Python executable path
+  // ===========================================
+
+  describe('Python Path Resolution', () => {
+    it('should use getPythonPath for the executable', async () => {
+      const pythonPath = manager.getPythonPath();
+      expect(pythonPath).toBeDefined();
+      expect(typeof pythonPath).toBe('string');
+    });
+
+    it('should return python3 in development on non-Windows', () => {
+      // The mock has isPackaged: false
+      const pythonPath = manager.getPythonPath();
+      // On Linux test environment, should return python3
+      expect(['python', 'python3']).toContain(pythonPath);
+    });
+  });
+
+  // ===========================================
+  // T008.1.3.2 - Spawn uvicorn process with correct args
+  // ===========================================
+
+  describe('Process Spawning', () => {
+    it('should call spawn when starting AI service', async () => {
+      // Simulate spawn event after a tick
+      setTimeout(() => mockProcess.emit('spawn'), 10);
+
+      await manager.startAIService();
+
+      expect(mockSpawn).toHaveBeenCalled();
+    });
+
+    it('should spawn with Python executable path', async () => {
+      setTimeout(() => mockProcess.emit('spawn'), 10);
+
+      await manager.startAIService();
+
+      const pythonPath = manager.getPythonPath();
+      expect(mockSpawn).toHaveBeenCalledWith(
+        pythonPath,
+        expect.any(Array),
+        expect.any(Object)
+      );
+    });
+
+    it('should spawn with uvicorn module arguments', async () => {
+      setTimeout(() => mockProcess.emit('spawn'), 10);
+
+      await manager.startAIService();
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.arrayContaining(['-m', 'uvicorn']),
+        expect.any(Object)
+      );
+    });
+
+    it('should include main:app in uvicorn arguments', async () => {
+      setTimeout(() => mockProcess.emit('spawn'), 10);
+
+      await manager.startAIService();
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.arrayContaining(['main:app']),
+        expect.any(Object)
+      );
+    });
+
+    it('should include host and port in uvicorn arguments', async () => {
+      setTimeout(() => mockProcess.emit('spawn'), 10);
+
+      await manager.startAIService();
+
+      const config = manager.getConfig();
+      expect(mockSpawn).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.arrayContaining([
+          '--host', '127.0.0.1',
+          '--port', String(config.aiServicePort),
+        ]),
+        expect.any(Object)
+      );
+    });
+
+    it('should spawn with cwd set to AI service path', async () => {
+      setTimeout(() => mockProcess.emit('spawn'), 10);
+
+      await manager.startAIService();
+
+      const aiPath = manager.getAIServicePath();
+      expect(mockSpawn).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Array),
+        expect.objectContaining({
+          cwd: expect.stringContaining('ai-service'),
+        })
+      );
+    });
+
+    it('should spawn with shell:false for security', async () => {
+      setTimeout(() => mockProcess.emit('spawn'), 10);
+
+      await manager.startAIService();
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Array),
+        expect.objectContaining({
+          shell: false,
+        })
+      );
+    });
+
+    it('should store process reference after spawn', async () => {
+      setTimeout(() => mockProcess.emit('spawn'), 10);
+
+      await manager.startAIService();
+
+      const health = await manager.checkHealth('ai');
+      expect(health.pid).toBe(mockProcess.pid);
+    });
+  });
+
+  // ===========================================
+  // T008.1.3.3 - Capture stdout/stderr for logging
+  // ===========================================
+
+  describe('Output Capture', () => {
+    it('should capture stdout from the process', async () => {
+      const logSpy = jest.spyOn(console, 'log').mockImplementation();
+
+      setTimeout(() => {
+        mockProcess.emit('spawn');
+        mockProcess.stdout.emit('data', Buffer.from('AI Service started on port 8000'));
+      }, 10);
+
+      await manager.startAIService();
+
+      // Give time for stdout event to be processed
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('AI Service')
+      );
+
+      logSpy.mockRestore();
+    });
+
+    it('should capture stderr from the process', async () => {
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      setTimeout(() => {
+        mockProcess.emit('spawn');
+        mockProcess.stderr.emit('data', Buffer.from('Warning: some warning'));
+      }, 10);
+
+      await manager.startAIService();
+
+      // Give time for stderr event to be processed
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      expect(errorSpy).toHaveBeenCalled();
+
+      errorSpy.mockRestore();
+    });
+
+    it('should have getProcessLogs method', () => {
+      expect(manager.getProcessLogs).toBeDefined();
+      expect(typeof manager.getProcessLogs).toBe('function');
+    });
+
+    it('should return logs for AI service', () => {
+      const logs = manager.getProcessLogs('ai');
+      expect(logs).toBeDefined();
+      expect(Array.isArray(logs)).toBe(true);
+    });
+  });
+
+  // ===========================================
+  // Process Event Handling
+  // ===========================================
+
+  describe('Process Event Handling', () => {
+    it('should set status to RUNNING on spawn event', async () => {
+      setTimeout(() => mockProcess.emit('spawn'), 10);
+
+      await manager.startAIService();
+
+      expect(manager.getAIServiceStatus()).toBe(ServiceStatus.RUNNING);
+    });
+
+    it('should set status to ERROR on error event', async () => {
+      setTimeout(() => {
+        mockProcess.emit('error', new Error('Failed to spawn'));
+      }, 10);
+
+      try {
+        await manager.startAIService();
+      } catch {
+        // Expected to throw or reject
+      }
+
+      expect(manager.getAIServiceStatus()).toBe(ServiceStatus.ERROR);
+    });
+
+    it('should set lastError on error event', async () => {
+      setTimeout(() => {
+        mockProcess.emit('error', new Error('Failed to spawn'));
+      }, 10);
+
+      try {
+        await manager.startAIService();
+      } catch {
+        // Expected
+      }
+
+      const error = manager.getLastError('ai');
+      expect(error).toContain('Failed to spawn');
+    });
+
+    it('should set status to STOPPED on exit event', async () => {
+      setTimeout(() => mockProcess.emit('spawn'), 10);
+
+      await manager.startAIService();
+      expect(manager.getAIServiceStatus()).toBe(ServiceStatus.RUNNING);
+
+      // Simulate process exit
+      mockProcess.emit('exit', 0, null);
+
+      expect(manager.getAIServiceStatus()).toBe(ServiceStatus.STOPPED);
+    });
+
+    it('should set status to ERROR on non-zero exit code', async () => {
+      setTimeout(() => mockProcess.emit('spawn'), 10);
+
+      await manager.startAIService();
+
+      // Simulate process crash
+      mockProcess.emit('exit', 1, null);
+
+      expect(manager.getAIServiceStatus()).toBe(ServiceStatus.ERROR);
+    });
+
+    it('should emit error event when process fails', async () => {
+      const errorListener = jest.fn();
+      manager.on('error', errorListener);
+
+      setTimeout(() => {
+        mockProcess.emit('error', new Error('Spawn failed'));
+      }, 10);
+
+      try {
+        await manager.startAIService();
+      } catch {
+        // Expected
+      }
+
+      expect(errorListener).toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================
+  // Timeout Handling
+  // ===========================================
+
+  describe('Startup Timeout', () => {
+    it('should have configurable startup timeout', () => {
+      const config = manager.getConfig();
+      expect(config).toHaveProperty('startupTimeoutMs');
+    });
+
+    it('should reject if spawn event not received within timeout', async () => {
+      // Don't emit spawn event - let it timeout
+      jest.useFakeTimers();
+
+      const startPromise = manager.startAIService();
+
+      // Fast-forward past timeout
+      jest.advanceTimersByTime(30000);
+
+      jest.useRealTimers();
+
+      await expect(startPromise).rejects.toThrow(/timeout/i);
+    }, 10000);
   });
 });

--- a/log_files/T008.1.3_StartAIServiceSpawning_Log.md
+++ b/log_files/T008.1.3_StartAIServiceSpawning_Log.md
@@ -1,0 +1,136 @@
+# T008.1.3 Implementation Log: startAIService Process Spawning
+
+## Task Overview
+- **Task ID**: T008.1.3
+- **Task Name**: Implement startAIService() method
+- **Status**: Completed
+- **Date**: 2025-12-17
+
+## Implementation Details
+
+### Sub-subtasks Completed
+
+#### T008.1.3.1 - Locate Python executable path
+- Uses `getPythonPath()` from T008.1.2
+- Development: `python3` (Linux/Mac) or `python` (Windows)
+- Production: Bundled Python in `process.resourcesPath`
+
+#### T008.1.3.2 - Spawn uvicorn process with correct args
+```typescript
+const args = [
+  '-m', 'uvicorn',
+  'main:app',
+  '--host', '127.0.0.1',
+  '--port', String(this.config.aiServicePort),
+];
+
+const spawnOptions = {
+  cwd: path.join(aiServicePath, 'src'),
+  shell: false,
+  stdio: ['ignore', 'pipe', 'pipe'] as const,
+};
+
+this.aiServiceProcess = spawn(pythonPath, args, spawnOptions);
+```
+
+#### T008.1.3.3 - Capture stdout/stderr for logging
+```typescript
+// Capture stdout
+this.aiServiceProcess.stdout.on('data', (data: Buffer) => {
+  const message = data.toString().trim();
+  if (message) {
+    this.addLog('ai', 'stdout', message);
+  }
+});
+
+// Capture stderr
+this.aiServiceProcess.stderr.on('data', (data: Buffer) => {
+  const message = data.toString().trim();
+  if (message) {
+    this.addLog('ai', 'stderr', message);
+  }
+});
+```
+
+### Files Modified
+- `desktop-app/src/main/process-manager.ts`
+- `desktop-app/tests/main/process-manager.test.ts`
+
+### New Features
+
+#### 1. startupTimeoutMs Configuration
+- Added to `ProcessManagerConfig` interface
+- Default: 30000ms (30 seconds)
+- Rejects Promise if spawn event not received within timeout
+
+#### 2. ProcessLogEntry Interface
+```typescript
+export interface ProcessLogEntry {
+  timestamp: Date;
+  level: 'stdout' | 'stderr';
+  message: string;
+}
+```
+
+#### 3. Process Logging Methods
+- `getProcessLogs(service)` - Returns array of log entries
+- `addLog(service, level, message)` - Internal method to add logs
+- `clearProcessLogs(service)` - Clear logs for a service
+- Max 1000 log entries kept per service
+
+#### 4. Process Event Handling
+- `spawn` event: Sets status to RUNNING, resolves Promise
+- `error` event: Sets status to ERROR, sets lastError, rejects Promise
+- `exit` event: Sets status based on exit code (STOPPED or ERROR)
+
+#### 5. Error Event Emission
+- `emitError()` method emits 'error' event to listeners
+
+### Security Considerations
+- `shell: false` prevents command injection
+- Binds to `127.0.0.1` (localhost only)
+- Process runs in isolated cwd
+
+## Test Coverage
+
+### New T008.1.3 Tests (22 tests)
+| Category | Tests |
+|----------|-------|
+| Python Path Resolution | 2 |
+| Process Spawning | 8 |
+| Output Capture | 4 |
+| Process Event Handling | 6 |
+| Startup Timeout | 2 |
+
+### Total Test Suite
+- **T008.1.1 tests**: 42 passed
+- **T008.1.2 tests**: 37 passed
+- **T008.1.3 tests**: 22 passed
+- **Total**: 101 passed
+
+## Architecture
+
+```
+startAIService()
+    │
+    ├── Check if already running → return early
+    │
+    ├── Update status to STARTING
+    │
+    ├── Resolve paths
+    │   ├── getPythonPath()
+    │   └── getAIServicePath() + '/src'
+    │
+    ├── Build arguments for uvicorn
+    │
+    ├── spawn(python, args, options)
+    │
+    ├── Setup timeout (30s default)
+    │
+    ├── Handle events
+    │   ├── 'spawn' → RUNNING, resolve
+    │   ├── 'error' → ERROR, reject
+    │   └── 'exit' → STOPPED or ERROR
+    │
+    └── Capture stdout/stderr → addLog()
+```

--- a/log_learn/T008.1.3_StartAIServiceSpawning_Guide.md
+++ b/log_learn/T008.1.3_StartAIServiceSpawning_Guide.md
@@ -1,0 +1,228 @@
+# T008.1.3 Learning Guide: Process Spawning in Electron
+
+## Overview
+
+This guide explains how to spawn and manage child processes in an Electron application, specifically for starting external services like a Python/FastAPI backend.
+
+## Key Concepts
+
+### 1. Node.js child_process.spawn
+
+The `spawn` function creates a new process without blocking:
+
+```typescript
+import { spawn, ChildProcess } from 'child_process';
+
+const process = spawn(command, args, options);
+```
+
+**Options:**
+- `cwd`: Working directory for the process
+- `shell`: Whether to run in shell (false for security)
+- `stdio`: How to handle stdin/stdout/stderr
+
+### 2. stdio Configuration
+
+```typescript
+const spawnOptions = {
+  stdio: ['ignore', 'pipe', 'pipe'] as const,
+  // [stdin, stdout, stderr]
+  // 'ignore' - don't create stream
+  // 'pipe' - create pipe to parent
+  // 'inherit' - use parent's streams
+};
+```
+
+### 3. Event-Based Process Management
+
+Child processes emit events:
+
+```typescript
+// Process started successfully
+process.on('spawn', () => {
+  console.log('Process spawned');
+});
+
+// Failed to start
+process.on('error', (err: Error) => {
+  console.error('Failed to spawn:', err.message);
+});
+
+// Process exited
+process.on('exit', (code: number | null, signal: string | null) => {
+  if (code === 0) {
+    console.log('Process exited normally');
+  } else {
+    console.log(`Process exited with code ${code}`);
+  }
+});
+```
+
+### 4. Capturing Output
+
+```typescript
+// stdout
+process.stdout?.on('data', (data: Buffer) => {
+  const message = data.toString().trim();
+  console.log('[stdout]', message);
+});
+
+// stderr
+process.stderr?.on('data', (data: Buffer) => {
+  const message = data.toString().trim();
+  console.error('[stderr]', message);
+});
+```
+
+### 5. Promise Wrapper Pattern
+
+Wrap spawn in a Promise for async/await:
+
+```typescript
+async startService(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const process = spawn(command, args, options);
+
+    // Timeout
+    const timeoutId = setTimeout(() => {
+      reject(new Error('Startup timeout'));
+    }, 30000);
+
+    // Success
+    process.on('spawn', () => {
+      clearTimeout(timeoutId);
+      resolve();
+    });
+
+    // Failure
+    process.on('error', (err) => {
+      clearTimeout(timeoutId);
+      reject(err);
+    });
+  });
+}
+```
+
+## Security Considerations
+
+### 1. Avoid Shell Execution
+
+```typescript
+// BAD - vulnerable to command injection
+spawn('python', [userInput], { shell: true });
+
+// GOOD - no shell, args are separate
+spawn('python', ['-m', 'uvicorn', 'main:app'], { shell: false });
+```
+
+### 2. Bind to Localhost
+
+```typescript
+const args = [
+  '-m', 'uvicorn', 'main:app',
+  '--host', '127.0.0.1',  // Only accessible locally
+  '--port', '8000',
+];
+```
+
+### 3. Validate Paths
+
+```typescript
+getAIServicePath(): string {
+  if (app.isPackaged) {
+    // Known, safe bundled path
+    return path.join(process.resourcesPath, 'ai-service');
+  }
+  // Development path, relative to app
+  return path.join(app.getAppPath(), '..', 'ai-service');
+}
+```
+
+## Testing Patterns
+
+### Mock EventEmitter for ChildProcess
+
+```typescript
+import { EventEmitter } from 'events';
+
+function createMockChildProcess() {
+  const mockProcess = new EventEmitter() as EventEmitter & {
+    pid: number;
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: jest.Mock;
+  };
+  mockProcess.pid = 12345;
+  mockProcess.stdout = new EventEmitter();
+  mockProcess.stderr = new EventEmitter();
+  mockProcess.kill = jest.fn();
+  return mockProcess;
+}
+```
+
+### Simulate Events in Tests
+
+```typescript
+it('should handle spawn event', async () => {
+  // Emit spawn after spawn() is called
+  setTimeout(() => mockProcess.emit('spawn'), 10);
+
+  await manager.startService();
+
+  expect(manager.isRunning()).toBe(true);
+});
+```
+
+### Test Timeouts with Fake Timers
+
+```typescript
+it('should timeout if no spawn event', async () => {
+  jest.useFakeTimers();
+
+  const promise = manager.startService();
+  jest.advanceTimersByTime(30000);
+
+  jest.useRealTimers();
+  await expect(promise).rejects.toThrow(/timeout/i);
+});
+```
+
+## Log Management
+
+### Log Entry Structure
+
+```typescript
+interface ProcessLogEntry {
+  timestamp: Date;
+  level: 'stdout' | 'stderr';
+  message: string;
+}
+```
+
+### Circular Buffer Pattern
+
+```typescript
+private readonly MAX_LOG_ENTRIES = 1000;
+
+private addLog(level: 'stdout' | 'stderr', message: string): void {
+  this.logs.push({ timestamp: new Date(), level, message });
+
+  // Keep only last N entries
+  if (this.logs.length > this.MAX_LOG_ENTRIES) {
+    this.logs.shift();
+  }
+}
+```
+
+## Related Tasks
+
+- **T008.1.4**: Implement stopAIService (SIGTERM, timeout, force kill)
+- **T008.1.5**: Implement restartAIService
+- **T008.1.6**: Implement health check polling
+- **T008.2**: Bridge service management
+
+## References
+
+- [Node.js child_process](https://nodejs.org/api/child_process.html#child_processspawncommand-args-options)
+- [Electron Process Model](https://www.electronjs.org/docs/latest/tutorial/process-model)
+- [uvicorn Documentation](https://www.uvicorn.org/)

--- a/log_tests/T008.1.3_StartAIServiceSpawning_TestLog.md
+++ b/log_tests/T008.1.3_StartAIServiceSpawning_TestLog.md
@@ -1,0 +1,136 @@
+# T008.1.3 Test Log: startAIService Process Spawning
+
+## Test Overview
+- **Task ID**: T008.1.3
+- **Test File**: `desktop-app/tests/main/process-manager.test.ts`
+- **New Tests Added**: 22
+- **Total Tests**: 101 (79 previous + 22 new)
+- **Framework**: Jest, ts-jest
+- **Date**: 2025-12-17
+
+## Mock Setup
+
+```typescript
+function createMockChildProcess() {
+  const mockProcess = new EventEmitter() as EventEmitter & {
+    pid: number;
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: jest.Mock;
+    killed: boolean;
+  };
+  mockProcess.pid = 12345;
+  mockProcess.stdout = new EventEmitter();
+  mockProcess.stderr = new EventEmitter();
+  mockProcess.kill = jest.fn().mockImplementation(() => {
+    mockProcess.killed = true;
+    mockProcess.emit('exit', 0, null);
+    return true;
+  });
+  mockProcess.killed = false;
+  return mockProcess;
+}
+
+// In beforeEach:
+mockSpawn.mockImplementation(() => {
+  setTimeout(() => mockProcess.emit('spawn'), 10);
+  return mockProcess as never;
+});
+```
+
+## New Test Categories for T008.1.3
+
+### Python Path Resolution (2 tests)
+| Test | Description |
+|------|-------------|
+| should use getPythonPath for the executable | Verify path method used |
+| should return python3 in development | Dev mode uses system Python |
+
+### Process Spawning (8 tests)
+| Test | Description |
+|------|-------------|
+| should call spawn when starting AI service | spawn() is called |
+| should spawn with Python executable path | First arg is Python path |
+| should spawn with uvicorn module arguments | Includes -m uvicorn |
+| should include main:app in arguments | Includes main:app |
+| should include host and port | Includes --host --port |
+| should spawn with cwd set to AI service path | cwd contains ai-service |
+| should spawn with shell:false for security | Security: no shell |
+| should store process reference after spawn | PID available |
+
+### Output Capture (4 tests)
+| Test | Description |
+|------|-------------|
+| should capture stdout from the process | stdout logged |
+| should capture stderr from the process | stderr logged |
+| should have getProcessLogs method | Method exists |
+| should return logs for AI service | Returns array |
+
+### Process Event Handling (6 tests)
+| Test | Description |
+|------|-------------|
+| should set status to RUNNING on spawn event | spawn → RUNNING |
+| should set status to ERROR on error event | error → ERROR |
+| should set lastError on error event | Error message stored |
+| should set status to STOPPED on exit event | exit(0) → STOPPED |
+| should set status to ERROR on non-zero exit | exit(1) → ERROR |
+| should emit error event when process fails | Error event emitted |
+
+### Startup Timeout (2 tests)
+| Test | Description |
+|------|-------------|
+| should have configurable startup timeout | Config has startupTimeoutMs |
+| should reject if spawn not received in time | Timeout triggers reject |
+
+## Test Execution
+
+```bash
+npm test -- --testPathPattern="process-manager" --verbose
+```
+
+## Results
+
+```
+Test Suites: 1 passed, 1 total
+Tests:       101 passed, 101 total
+Time:        6.672 s
+```
+
+## Key Testing Patterns
+
+### Testing async spawn with setTimeout
+```typescript
+it('should call spawn when starting AI service', async () => {
+  setTimeout(() => mockProcess.emit('spawn'), 10);
+  await manager.startAIService();
+  expect(mockSpawn).toHaveBeenCalled();
+});
+```
+
+### Testing error handling
+```typescript
+it('should set status to ERROR on error event', async () => {
+  setTimeout(() => {
+    mockProcess.emit('error', new Error('Failed to spawn'));
+  }, 10);
+
+  try {
+    await manager.startAIService();
+  } catch {
+    // Expected
+  }
+
+  expect(manager.getAIServiceStatus()).toBe(ServiceStatus.ERROR);
+});
+```
+
+### Testing timeout with fake timers
+```typescript
+it('should reject if spawn event not received within timeout', async () => {
+  jest.useFakeTimers();
+  const startPromise = manager.startAIService();
+  jest.advanceTimersByTime(30000);
+  jest.useRealTimers();
+  await expect(startPromise).rejects.toThrow(/timeout/i);
+});
+```

--- a/specs/001-windows-native-ai/tasks.md
+++ b/specs/001-windows-native-ai/tasks.md
@@ -659,10 +659,19 @@
     - Added: updateStatus() helper for centralized status changes
     - Test: 37 new tests (79 total) - all pass
     - Logs: `log_files/T008.1.2_*`, `log_tests/T008.1.2_*`, `log_learn/T008.1.2_*`
-  - [ ] T008.1.3 Implement `startAIService()` method
-    - [ ] T008.1.3.1 Locate Python executable path
-    - [ ] T008.1.3.2 Spawn uvicorn process with correct args
-    - [ ] T008.1.3.3 Capture stdout/stderr for logging
+  - [x] T008.1.3 Implement `startAIService()` method ✅ *Completed 2025-12-17*
+    - [x] T008.1.3.1 Locate Python executable path - Uses getPythonPath()
+    - [x] T008.1.3.2 Spawn uvicorn process with correct args
+      - Args: `-m uvicorn main:app --host 127.0.0.1 --port {port}`
+      - Options: `cwd: ai-service/src, shell: false`
+    - [x] T008.1.3.3 Capture stdout/stderr for logging
+      - Added: ProcessLogEntry interface, getProcessLogs(), addLog()
+      - Max 1000 log entries per service
+    - Added: startupTimeoutMs config (30s default)
+    - Added: Process event handling (spawn, error, exit)
+    - Added: emitError() for error event emission
+    - Test: 22 new tests (101 total) - all pass
+    - Logs: `log_files/T008.1.3_*`, `log_tests/T008.1.3_*`, `log_learn/T008.1.3_*`
   - [ ] T008.1.4 Implement `stopAIService()` method
     - [ ] T008.1.4.1 Send SIGTERM to process
     - [ ] T008.1.4.2 Wait for graceful shutdown (5s timeout)


### PR DESCRIPTION
- Spawn Python/uvicorn process with correct arguments
- Add startupTimeoutMs config (30s default)
- Add ProcessLogEntry interface and logging methods
- Handle spawn, error, exit events properly
- Capture stdout/stderr with circular buffer (1000 entries)
- Add emitError() for error event emission
- Add 22 new tests (101 total) - all pass