### PR TITLE
feat(T008.1.4): implement stopAIService with graceful shutdown

### DIFF
--- a/desktop-app/src/main/process-manager.ts
+++ b/desktop-app/src/main/process-manager.ts
@@ -65,6 +65,7 @@ export interface ProcessManagerConfig {
   maxRestartAttempts: number;
   restartBackoffMs: number;
   startupTimeoutMs: number;  // T008.1.3: Timeout for process startup
+  shutdownTimeoutMs: number; // T008.1.4: Timeout for graceful shutdown before force kill
 }
 
 /**
@@ -86,6 +87,7 @@ const DEFAULT_CONFIG: ProcessManagerConfig = {
   maxRestartAttempts: 3,
   restartBackoffMs: 1000,
   startupTimeoutMs: 30000,  // T008.1.3: 30 second default timeout
+  shutdownTimeoutMs: 5000,  // T008.1.4: 5 second default for graceful shutdown
 };
 
 /**
@@ -503,6 +505,7 @@ export class ProcessManager {
 
   /**
    * Stop the AI Service
+   * T008.1.4: Graceful shutdown with SIGTERM, force kill with SIGKILL after timeout
    * @returns Promise that resolves when service is stopped
    */
   async stopAIService(): Promise<void> {
@@ -514,18 +517,80 @@ export class ProcessManager {
     this.updateStatus('ai', ServiceStatus.STOPPING);
     console.log('Stopping AI Service...');
 
-    // TODO: Implement actual process termination in T008.1.4
-    // This is a stub that simulates successful stop
+    // If no process exists (e.g., already crashed), just clean up
+    if (!this.aiServiceProcess) {
+      this.aiServiceProcess = null;
+      this.updateStatus('ai', ServiceStatus.STOPPED);
+      console.log('AI Service stopped (no process)');
+      return;
+    }
+
     return new Promise((resolve) => {
-      setTimeout(() => {
-        if (this.aiServiceProcess) {
-          this.aiServiceProcess.kill();
-          this.aiServiceProcess = null;
+      const process = this.aiServiceProcess!;
+      let shutdownTimeoutId: NodeJS.Timeout | null = null;
+      let forceKillTimeoutId: NodeJS.Timeout | null = null;
+      let isResolved = false;
+
+      // Handler for process exit
+      const onExit = () => {
+        if (isResolved) return;
+        isResolved = true;
+
+        // Clear timeouts
+        if (shutdownTimeoutId) {
+          clearTimeout(shutdownTimeoutId);
+          shutdownTimeoutId = null;
         }
+        if (forceKillTimeoutId) {
+          clearTimeout(forceKillTimeoutId);
+          forceKillTimeoutId = null;
+        }
+
+        // Clean up
+        this.aiServiceProcess = null;
         this.updateStatus('ai', ServiceStatus.STOPPED);
-        console.log('AI Service stopped (stub)');
+        console.log('AI Service stopped');
         resolve();
-      }, 100);
+      };
+
+      // Listen for exit event
+      process.once('exit', onExit);
+
+      // T008.1.4.1: Send SIGTERM for graceful shutdown
+      try {
+        process.kill('SIGTERM');
+        console.log('Sent SIGTERM to AI Service');
+      } catch (error) {
+        // Process may already be dead
+        console.log('Failed to send SIGTERM (process may have already exited)');
+        onExit();
+        return;
+      }
+
+      // T008.1.4.2: Set timeout for graceful shutdown
+      shutdownTimeoutId = setTimeout(() => {
+        if (isResolved) return;
+
+        // T008.1.4.3: Force kill with SIGKILL
+        console.warn('AI Service did not shut down gracefully, force killing...');
+
+        try {
+          process.kill('SIGKILL');
+        } catch {
+          // Process may already be dead
+          console.log('Failed to send SIGKILL (process may have already exited)');
+        }
+
+        // Give SIGKILL a brief moment to take effect, then force resolve
+        forceKillTimeoutId = setTimeout(() => {
+          if (isResolved) return;
+
+          // Force cleanup even if process didn't respond
+          console.warn('AI Service process did not respond to SIGKILL, force cleaning up');
+          process.removeListener('exit', onExit);
+          onExit();
+        }, 1000); // 1 second grace period for SIGKILL
+      }, this.config.shutdownTimeoutMs);
     });
   }
 

--- a/desktop-app/tests/main/process-manager.test.ts
+++ b/desktop-app/tests/main/process-manager.test.ts
@@ -178,14 +178,25 @@ describe('ProcessManager', () => {
       await manager.startAIService();
       expect(manager.getAIServiceStatus()).toBe(ServiceStatus.RUNNING);
 
-      const stopPromise = manager.stopAIService();
+      // Track status transitions via events
+      const statusTransitions: ServiceStatus[] = [];
+      manager.on('statusChange', (event) => {
+        if (event.service === 'ai') {
+          statusTransitions.push(event.status);
+        }
+      });
 
-      // Status should be STOPPING after call
-      expect(manager.getAIServiceStatus()).toBe(ServiceStatus.STOPPING);
+      // Setup kill to emit exit with slight delay so we can observe STOPPING
+      mockProcess.kill.mockImplementation(() => {
+        setTimeout(() => mockProcess.emit('exit', 0, 'SIGTERM'), 10);
+        return true;
+      });
 
-      await stopPromise;
+      await manager.stopAIService();
 
-      // Status should be STOPPED after completion
+      // Should have transitioned through STOPPING to STOPPED
+      expect(statusTransitions).toContain(ServiceStatus.STOPPING);
+      expect(statusTransitions).toContain(ServiceStatus.STOPPED);
       expect(manager.getAIServiceStatus()).toBe(ServiceStatus.STOPPED);
     });
 
@@ -1069,5 +1080,488 @@ describe('ProcessManager startAIService Spawning (T008.1.3)', () => {
 
       await expect(startPromise).rejects.toThrow(/timeout/i);
     }, 10000);
+  });
+});
+
+// ===========================================
+// T008.1.4 - stopAIService Graceful Shutdown Tests
+// ===========================================
+
+describe('ProcessManager stopAIService Graceful Shutdown (T008.1.4)', () => {
+  let manager: ProcessManager;
+  let mockProcess: ReturnType<typeof createMockChildProcess>;
+  const mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
+
+  beforeEach(() => {
+    manager = new ProcessManager();
+    mockProcess = createMockChildProcess();
+    mockSpawn.mockImplementation(() => {
+      setTimeout(() => mockProcess.emit('spawn'), 10);
+      return mockProcess as never;
+    });
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  // Helper to start the service before testing stop
+  async function startService(): Promise<void> {
+    await manager.startAIService();
+    expect(manager.getAIServiceStatus()).toBe(ServiceStatus.RUNNING);
+  }
+
+  // ===========================================
+  // T008.1.4.1 - Send SIGTERM to process
+  // ===========================================
+
+  describe('SIGTERM Signal', () => {
+    it('should call kill with SIGTERM when stopping', async () => {
+      await startService();
+
+      // Setup mock to not auto-exit, simulate graceful shutdown
+      mockProcess.kill.mockImplementation(() => {
+        setTimeout(() => mockProcess.emit('exit', 0, 'SIGTERM'), 50);
+        return true;
+      });
+
+      await manager.stopAIService();
+
+      expect(mockProcess.kill).toHaveBeenCalledWith('SIGTERM');
+    });
+
+    it('should send SIGTERM as first termination signal', async () => {
+      await startService();
+
+      mockProcess.kill.mockImplementation(() => {
+        setTimeout(() => mockProcess.emit('exit', 0, 'SIGTERM'), 50);
+        return true;
+      });
+
+      await manager.stopAIService();
+
+      // First call should be SIGTERM
+      expect(mockProcess.kill.mock.calls[0][0]).toBe('SIGTERM');
+    });
+
+    it('should set status to STOPPING before sending signal', async () => {
+      await startService();
+
+      // Track status when kill is called
+      let statusWhenKilled: ServiceStatus | null = null;
+      mockProcess.kill.mockImplementation(() => {
+        statusWhenKilled = manager.getAIServiceStatus();
+        mockProcess.emit('exit', 0, 'SIGTERM');
+        return true;
+      });
+
+      await manager.stopAIService();
+
+      expect(statusWhenKilled).toBe(ServiceStatus.STOPPING);
+    });
+
+    it('should not call kill if already stopped', async () => {
+      // Don't start service - already stopped
+      expect(manager.getAIServiceStatus()).toBe(ServiceStatus.STOPPED);
+
+      await manager.stopAIService();
+
+      expect(mockProcess.kill).not.toHaveBeenCalled();
+    });
+
+    it('should not call kill if no process exists', async () => {
+      await startService();
+
+      // Simulate process already gone (e.g., crashed)
+      mockProcess.emit('exit', 1, null);
+      expect(manager.getAIServiceStatus()).toBe(ServiceStatus.ERROR);
+
+      // Clear mock to track new calls
+      mockProcess.kill.mockClear();
+
+      // Try to stop - should handle gracefully
+      await manager.stopAIService();
+
+      // Should not throw but may or may not call kill depending on implementation
+    });
+  });
+
+  // ===========================================
+  // T008.1.4.2 - Wait for graceful shutdown (5s timeout)
+  // ===========================================
+
+  describe('Graceful Shutdown Timeout', () => {
+    it('should have configurable shutdown timeout', () => {
+      const config = manager.getConfig();
+      expect(config).toHaveProperty('shutdownTimeoutMs');
+    });
+
+    it('should default shutdown timeout to 5000ms', () => {
+      const config = manager.getConfig();
+      expect(config.shutdownTimeoutMs).toBe(5000);
+    });
+
+    it('should wait for process to exit after SIGTERM', async () => {
+      await startService();
+
+      // Simulate delayed graceful shutdown
+      let exitCalled = false;
+      mockProcess.kill.mockImplementation(() => {
+        setTimeout(() => {
+          exitCalled = true;
+          mockProcess.emit('exit', 0, 'SIGTERM');
+        }, 100);
+        return true;
+      });
+
+      await manager.stopAIService();
+
+      expect(exitCalled).toBe(true);
+      expect(manager.getAIServiceStatus()).toBe(ServiceStatus.STOPPED);
+    });
+
+    it('should resolve Promise when process exits gracefully', async () => {
+      await startService();
+
+      mockProcess.kill.mockImplementation(() => {
+        setTimeout(() => mockProcess.emit('exit', 0, 'SIGTERM'), 50);
+        return true;
+      });
+
+      const stopPromise = manager.stopAIService();
+
+      await expect(stopPromise).resolves.toBeUndefined();
+      expect(manager.getAIServiceStatus()).toBe(ServiceStatus.STOPPED);
+    });
+
+    it('should set status to STOPPED after graceful shutdown', async () => {
+      await startService();
+
+      mockProcess.kill.mockImplementation(() => {
+        setTimeout(() => mockProcess.emit('exit', 0, 'SIGTERM'), 50);
+        return true;
+      });
+
+      await manager.stopAIService();
+
+      expect(manager.getAIServiceStatus()).toBe(ServiceStatus.STOPPED);
+    });
+
+    it('should clear process reference after shutdown', async () => {
+      await startService();
+
+      mockProcess.kill.mockImplementation(() => {
+        setTimeout(() => mockProcess.emit('exit', 0, 'SIGTERM'), 50);
+        return true;
+      });
+
+      await manager.stopAIService();
+
+      const health = await manager.checkHealth('ai');
+      expect(health.pid).toBeUndefined();
+    });
+  });
+
+  // ===========================================
+  // T008.1.4.3 - Force kill if timeout exceeded
+  // ===========================================
+
+  describe('Force Kill on Timeout', () => {
+    it('should send SIGKILL if SIGTERM times out', async () => {
+      // Use shorter timeout for test
+      const shortManager = new ProcessManager({ shutdownTimeoutMs: 100 });
+      const shortMockProcess = createMockChildProcess();
+      mockSpawn.mockImplementation(() => {
+        setTimeout(() => shortMockProcess.emit('spawn'), 10);
+        return shortMockProcess as never;
+      });
+
+      await shortManager.startAIService();
+
+      // Mock kill to not exit the process (simulating hung process)
+      shortMockProcess.kill.mockImplementation((signal: string) => {
+        if (signal === 'SIGKILL') {
+          shortMockProcess.emit('exit', null, 'SIGKILL');
+        }
+        // SIGTERM doesn't trigger exit (hung process)
+        return true;
+      });
+
+      await shortManager.stopAIService();
+
+      expect(shortMockProcess.kill).toHaveBeenCalledWith('SIGKILL');
+    }, 10000);
+
+    it('should call SIGKILL only after SIGTERM timeout', async () => {
+      // Use shorter timeout for test
+      const shortManager = new ProcessManager({ shutdownTimeoutMs: 100 });
+      const shortMockProcess = createMockChildProcess();
+      mockSpawn.mockImplementation(() => {
+        setTimeout(() => shortMockProcess.emit('spawn'), 10);
+        return shortMockProcess as never;
+      });
+
+      await shortManager.startAIService();
+
+      const killCalls: string[] = [];
+      shortMockProcess.kill.mockImplementation((signal: string) => {
+        killCalls.push(signal);
+        if (signal === 'SIGKILL') {
+          shortMockProcess.emit('exit', null, 'SIGKILL');
+        }
+        return true;
+      });
+
+      await shortManager.stopAIService();
+
+      // SIGTERM should be called first, then SIGKILL after timeout
+      expect(killCalls[0]).toBe('SIGTERM');
+      expect(killCalls).toContain('SIGKILL');
+    }, 10000);
+
+    it('should set status to STOPPED after force kill', async () => {
+      // Use shorter timeout for test
+      const shortManager = new ProcessManager({ shutdownTimeoutMs: 100 });
+      const shortMockProcess = createMockChildProcess();
+      mockSpawn.mockImplementation(() => {
+        setTimeout(() => shortMockProcess.emit('spawn'), 10);
+        return shortMockProcess as never;
+      });
+
+      await shortManager.startAIService();
+
+      shortMockProcess.kill.mockImplementation((signal: string) => {
+        if (signal === 'SIGKILL') {
+          shortMockProcess.emit('exit', null, 'SIGKILL');
+        }
+        return true;
+      });
+
+      await shortManager.stopAIService();
+
+      expect(shortManager.getAIServiceStatus()).toBe(ServiceStatus.STOPPED);
+    }, 10000);
+
+    it('should log warning when force kill is needed', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      // Use shorter timeout for test
+      const shortManager = new ProcessManager({ shutdownTimeoutMs: 100 });
+      const shortMockProcess = createMockChildProcess();
+      mockSpawn.mockImplementation(() => {
+        setTimeout(() => shortMockProcess.emit('spawn'), 10);
+        return shortMockProcess as never;
+      });
+
+      await shortManager.startAIService();
+
+      shortMockProcess.kill.mockImplementation((signal: string) => {
+        if (signal === 'SIGKILL') {
+          shortMockProcess.emit('exit', null, 'SIGKILL');
+        }
+        return true;
+      });
+
+      await shortManager.stopAIService();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('force')
+      );
+
+      warnSpy.mockRestore();
+    }, 10000);
+
+    it('should resolve even if both SIGTERM and SIGKILL fail', async () => {
+      // Use shorter timeout for test
+      const shortManager = new ProcessManager({ shutdownTimeoutMs: 100 });
+      const shortMockProcess = createMockChildProcess();
+      mockSpawn.mockImplementation(() => {
+        setTimeout(() => shortMockProcess.emit('spawn'), 10);
+        return shortMockProcess as never;
+      });
+
+      await shortManager.startAIService();
+
+      // Simulate process that ignores both signals
+      shortMockProcess.kill.mockReturnValue(false);
+
+      // Should still resolve (not hang forever) due to force cleanup
+      await expect(shortManager.stopAIService()).resolves.toBeUndefined();
+    }, 15000);
+  });
+
+  // ===========================================
+  // Edge Cases
+  // ===========================================
+
+  describe('Edge Cases', () => {
+    it('should handle multiple stop calls gracefully', async () => {
+      await startService();
+
+      // Setup mock to emit exit immediately on first kill
+      mockProcess.kill.mockImplementation(() => {
+        mockProcess.emit('exit', 0, 'SIGTERM');
+        return true;
+      });
+
+      // Call stop multiple times - second and third should return quickly
+      // because status transitions to STOPPING/STOPPED
+      await manager.stopAIService();
+      await manager.stopAIService();  // Should be no-op (already stopped)
+      await manager.stopAIService();  // Should be no-op (already stopped)
+
+      expect(manager.getAIServiceStatus()).toBe(ServiceStatus.STOPPED);
+    }, 10000);
+
+    it('should handle stop when process does not exist', async () => {
+      // Verify that stopping when no process exists works gracefully
+      // This simulates a case where status is not STOPPED but process is gone
+
+      // Start and immediately emit exit (process crashes before spawn)
+      const crashMockProcess = createMockChildProcess();
+      mockSpawn.mockImplementation(() => {
+        // Emit error before spawn (simulating early crash)
+        setTimeout(() => crashMockProcess.emit('error', new Error('Failed to start')), 10);
+        return crashMockProcess as never;
+      });
+
+      try {
+        await manager.startAIService();
+      } catch {
+        // Expected - service failed to start
+      }
+
+      expect(manager.getAIServiceStatus()).toBe(ServiceStatus.ERROR);
+
+      // Setup kill to emit exit
+      crashMockProcess.kill.mockImplementation(() => {
+        crashMockProcess.emit('exit', 0, 'SIGTERM');
+        return true;
+      });
+
+      // Stop should handle this gracefully
+      await manager.stopAIService();
+
+      expect(manager.getAIServiceStatus()).toBe(ServiceStatus.STOPPED);
+    }, 10000);
+
+    it('should emit statusChange event with correct previous status', async () => {
+      await startService();
+
+      const listener = jest.fn();
+      manager.on('statusChange', listener);
+
+      mockProcess.kill.mockImplementation(() => {
+        // Emit exit event synchronously
+        mockProcess.emit('exit', 0, 'SIGTERM');
+        return true;
+      });
+
+      await manager.stopAIService();
+
+      // Should have events for STOPPING and STOPPED
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          service: 'ai',
+          status: ServiceStatus.STOPPING,
+          previousStatus: ServiceStatus.RUNNING,
+        })
+      );
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          service: 'ai',
+          status: ServiceStatus.STOPPED,
+          previousStatus: ServiceStatus.STOPPING,
+        })
+      );
+    }, 10000);
+
+    it('should not throw if kill() throws an error', async () => {
+      await startService();
+
+      mockProcess.kill.mockImplementation(() => {
+        throw new Error('Process already terminated');
+      });
+
+      // Should not throw
+      await expect(manager.stopAIService()).resolves.toBeUndefined();
+
+      expect(manager.getAIServiceStatus()).toBe(ServiceStatus.STOPPED);
+    }, 10000);
+
+    it('should clear shutdown timeout when process exits gracefully', async () => {
+      await startService();
+
+      const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+
+      mockProcess.kill.mockImplementation(() => {
+        // Process exits immediately (synchronously)
+        mockProcess.emit('exit', 0, 'SIGTERM');
+        return true;
+      });
+
+      await manager.stopAIService();
+
+      // Timeout should be cleared when exit is received
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+
+      clearTimeoutSpy.mockRestore();
+    }, 10000);
+  });
+
+  // ===========================================
+  // Configuration Tests
+  // ===========================================
+
+  describe('Shutdown Configuration', () => {
+    it('should allow custom shutdown timeout via config', () => {
+      const customManager = new ProcessManager({
+        shutdownTimeoutMs: 10000,
+      });
+
+      const config = customManager.getConfig();
+      expect(config.shutdownTimeoutMs).toBe(10000);
+    });
+
+    it('should use custom shutdown timeout when stopping', async () => {
+      jest.useFakeTimers();
+
+      const customManager = new ProcessManager({
+        shutdownTimeoutMs: 2000, // 2 second timeout
+      });
+
+      const customMockProcess = createMockChildProcess();
+      mockSpawn.mockImplementation(() => {
+        setTimeout(() => customMockProcess.emit('spawn'), 10);
+        return customMockProcess as never;
+      });
+
+      // Need real timer for startAIService
+      jest.useRealTimers();
+      await customManager.startAIService();
+      jest.useFakeTimers();
+
+      let sigkillCalled = false;
+      customMockProcess.kill.mockImplementation((signal: string) => {
+        if (signal === 'SIGKILL') {
+          sigkillCalled = true;
+          customMockProcess.emit('exit', null, 'SIGKILL');
+        }
+        return true;
+      });
+
+      const stopPromise = customManager.stopAIService();
+
+      // Fast-forward 2 seconds (custom timeout)
+      jest.advanceTimersByTime(2000);
+
+      jest.useRealTimers();
+
+      await stopPromise;
+
+      expect(sigkillCalled).toBe(true);
+    });
   });
 });

--- a/log_files/T008.1.4_StopAIServiceGraceful_Log.md
+++ b/log_files/T008.1.4_StopAIServiceGraceful_Log.md
@@ -1,0 +1,123 @@
+# T008.1.4 Implementation Log: stopAIService Graceful Shutdown
+
+## Task Overview
+- **Task ID**: T008.1.4
+- **Task Name**: Implement stopAIService() with graceful shutdown
+- **Status**: Completed
+- **Date**: 2025-12-17
+
+## Implementation Details
+
+### Sub-subtasks Completed
+
+#### T008.1.4.1 - Send SIGTERM to process
+```typescript
+// T008.1.4.1: Send SIGTERM for graceful shutdown
+try {
+  process.kill('SIGTERM');
+  console.log('Sent SIGTERM to AI Service');
+} catch (error) {
+  // Process may already be dead
+  console.log('Failed to send SIGTERM (process may have already exited)');
+  onExit();
+  return;
+}
+```
+
+#### T008.1.4.2 - Wait for graceful shutdown (5s timeout)
+- Added `shutdownTimeoutMs` to config (default: 5000ms)
+- Process listens for `exit` event from child process
+- If exit received before timeout, resolves promise and cleans up
+
+#### T008.1.4.3 - Force kill if timeout exceeded
+```typescript
+// T008.1.4.3: Force kill with SIGKILL
+console.warn('AI Service did not shut down gracefully, force killing...');
+
+try {
+  process.kill('SIGKILL');
+} catch {
+  console.log('Failed to send SIGKILL (process may have already exited)');
+}
+
+// Give SIGKILL a brief moment to take effect, then force resolve
+forceKillTimeoutId = setTimeout(() => {
+  console.warn('AI Service process did not respond to SIGKILL, force cleaning up');
+  process.removeListener('exit', onExit);
+  onExit();
+}, 1000); // 1 second grace period for SIGKILL
+```
+
+### Files Modified
+- `desktop-app/src/main/process-manager.ts`
+- `desktop-app/tests/main/process-manager.test.ts`
+
+### New Features
+
+#### 1. shutdownTimeoutMs Configuration
+- Added to `ProcessManagerConfig` interface
+- Default: 5000ms (5 seconds)
+- Force kills with SIGKILL if graceful shutdown exceeds timeout
+
+#### 2. Graceful Shutdown Flow
+1. Set status to STOPPING
+2. Check if process exists
+3. Send SIGTERM signal
+4. Start shutdown timeout timer
+5. Wait for exit event
+6. If exit received: clear timeout, set status to STOPPED
+7. If timeout: send SIGKILL, wait 1s, force cleanup
+
+### Security Considerations
+- Uses SIGTERM first (allows process to cleanup)
+- Falls back to SIGKILL only if necessary
+- Handles edge cases where process is already dead
+- Prevents resource leaks with force cleanup
+
+## Test Coverage
+
+### New T008.1.4 Tests (23 tests)
+| Category | Tests |
+|----------|-------|
+| SIGTERM Signal | 5 |
+| Graceful Shutdown Timeout | 6 |
+| Force Kill on Timeout | 5 |
+| Edge Cases | 5 |
+| Shutdown Configuration | 2 |
+
+### Total Test Suite
+- **T008.1.1 tests**: 42 passed
+- **T008.1.2 tests**: 37 passed
+- **T008.1.3 tests**: 22 passed
+- **T008.1.4 tests**: 23 passed
+- **Total**: 124 passed
+
+## Architecture
+
+```
+stopAIService()
+    │
+    ├── Check if already STOPPED → return early
+    │
+    ├── Update status to STOPPING
+    │
+    ├── Check if process exists
+    │   └── If not → clean up and return
+    │
+    ├── Setup exit handler
+    │   └── On exit → clear timeouts, clean up, resolve
+    │
+    ├── Send SIGTERM
+    │   └── On error → process dead, clean up
+    │
+    ├── Start shutdown timeout (5s default)
+    │   │
+    │   ├── On timeout → log warning
+    │   │
+    │   ├── Send SIGKILL
+    │   │
+    │   └── Start SIGKILL grace period (1s)
+    │       └── On timeout → force cleanup
+    │
+    └── Wait for resolution
+```

--- a/log_learn/T008.1.4_StopAIServiceGraceful_Guide.md
+++ b/log_learn/T008.1.4_StopAIServiceGraceful_Guide.md
@@ -1,0 +1,256 @@
+# T008.1.4 Learning Guide: Graceful Process Shutdown in Node.js
+
+## Overview
+
+This guide explains how to gracefully stop child processes in Node.js/Electron applications, with proper signal handling and timeout-based force termination.
+
+## Key Concepts
+
+### 1. Process Signals
+
+Unix signals are used to communicate with processes:
+
+```typescript
+// SIGTERM - Graceful termination request
+// Process can catch this and cleanup before exiting
+process.kill('SIGTERM');
+
+// SIGKILL - Force terminate immediately
+// Process cannot catch or ignore this signal
+process.kill('SIGKILL');
+```
+
+### 2. Graceful Shutdown Pattern
+
+```typescript
+async stopProcess(): Promise<void> {
+  return new Promise((resolve) => {
+    const childProcess = this.process;
+
+    // Handler for when process exits
+    const onExit = () => {
+      this.process = null;
+      resolve();
+    };
+
+    // Listen for exit event
+    childProcess.once('exit', onExit);
+
+    // Send graceful termination signal
+    childProcess.kill('SIGTERM');
+  });
+}
+```
+
+### 3. Timeout with Force Kill
+
+```typescript
+async stopProcess(): Promise<void> {
+  return new Promise((resolve) => {
+    const childProcess = this.process;
+    let timeoutId: NodeJS.Timeout | null = null;
+
+    const onExit = () => {
+      if (timeoutId) clearTimeout(timeoutId);
+      this.process = null;
+      resolve();
+    };
+
+    childProcess.once('exit', onExit);
+    childProcess.kill('SIGTERM');
+
+    // Timeout for graceful shutdown
+    timeoutId = setTimeout(() => {
+      console.warn('Process did not exit gracefully, force killing...');
+      childProcess.kill('SIGKILL');
+    }, 5000);
+  });
+}
+```
+
+### 4. Double Timeout Pattern (Recommended)
+
+The implementation uses two timeouts:
+1. Graceful shutdown timeout (5s) - triggers SIGKILL
+2. SIGKILL grace period (1s) - force cleanup if SIGKILL fails
+
+```typescript
+// First timeout: graceful shutdown
+shutdownTimeoutId = setTimeout(() => {
+  process.kill('SIGKILL');
+
+  // Second timeout: force cleanup
+  forceKillTimeoutId = setTimeout(() => {
+    // Force cleanup even if process didn't respond
+    process.removeListener('exit', onExit);
+    onExit();
+  }, 1000);
+}, this.config.shutdownTimeoutMs);
+```
+
+## Error Handling
+
+### Handle Already Dead Processes
+
+```typescript
+try {
+  process.kill('SIGTERM');
+} catch (error) {
+  // Process may already be dead
+  // Clean up and resolve immediately
+  onExit();
+  return;
+}
+```
+
+### Handle Kill Failures
+
+```typescript
+try {
+  process.kill('SIGKILL');
+} catch {
+  // Process may have already exited between SIGTERM timeout
+  // and SIGKILL attempt - this is fine
+}
+```
+
+## State Management
+
+### Using isResolved Flag
+
+Prevent multiple resolutions when multiple completion paths exist:
+
+```typescript
+let isResolved = false;
+
+const onExit = () => {
+  if (isResolved) return;
+  isResolved = true;
+
+  // Clear all timeouts
+  if (shutdownTimeoutId) clearTimeout(shutdownTimeoutId);
+  if (forceKillTimeoutId) clearTimeout(forceKillTimeoutId);
+
+  // Clean up
+  this.process = null;
+  resolve();
+};
+```
+
+### Status Transitions
+
+```
+RUNNING → STOPPING → STOPPED
+              ↓
+           (timeout)
+              ↓
+          SIGKILL
+              ↓
+          STOPPED
+```
+
+## Testing Patterns
+
+### Testing Graceful Shutdown
+
+```typescript
+it('should stop gracefully', async () => {
+  await startService();
+
+  mockProcess.kill.mockImplementation(() => {
+    // Simulate graceful exit
+    setTimeout(() => mockProcess.emit('exit', 0, 'SIGTERM'), 50);
+    return true;
+  });
+
+  await manager.stopService();
+
+  expect(manager.getStatus()).toBe('stopped');
+});
+```
+
+### Testing Force Kill
+
+```typescript
+it('should force kill on timeout', async () => {
+  // Use short timeout for fast tests
+  const manager = new ProcessManager({ shutdownTimeoutMs: 100 });
+  await manager.startService();
+
+  mockProcess.kill.mockImplementation((signal: string) => {
+    // Only respond to SIGKILL (simulating hung process)
+    if (signal === 'SIGKILL') {
+      mockProcess.emit('exit', null, 'SIGKILL');
+    }
+    return true;
+  });
+
+  await manager.stopService();
+
+  expect(mockProcess.kill).toHaveBeenCalledWith('SIGKILL');
+});
+```
+
+### Testing Error Handling
+
+```typescript
+it('should handle kill errors', async () => {
+  await startService();
+
+  mockProcess.kill.mockImplementation(() => {
+    throw new Error('Process already terminated');
+  });
+
+  // Should not throw
+  await expect(manager.stopService()).resolves.toBeUndefined();
+});
+```
+
+## Best Practices
+
+### 1. Always Allow Graceful Shutdown First
+Give processes a chance to cleanup (save state, close connections, etc.)
+
+### 2. Configurable Timeouts
+```typescript
+interface Config {
+  shutdownTimeoutMs: number; // Default: 5000
+}
+```
+
+### 3. Log Force Kills
+```typescript
+console.warn('Process did not shut down gracefully, force killing...');
+```
+
+### 4. Clean Up Resources
+Always clear references and reset state, even if process misbehaves:
+```typescript
+const onExit = () => {
+  this.process = null;
+  this.status = 'stopped';
+};
+```
+
+### 5. Handle Concurrent Stop Calls
+```typescript
+if (this.status === ServiceStatus.STOPPED) {
+  return; // Already stopped
+}
+if (this.status === ServiceStatus.STOPPING) {
+  // Could return existing promise or wait for completion
+}
+```
+
+## Related Tasks
+
+- **T008.1.3**: Implemented startAIService (process spawning)
+- **T008.1.5**: Implement restartAIService
+- **T008.1.6**: Implement health check polling
+- **T008.2.2**: Implement stopBridgeService (similar pattern)
+
+## References
+
+- [Node.js Child Process - kill()](https://nodejs.org/api/child_process.html#subprocesskillsignal)
+- [Unix Signals](https://en.wikipedia.org/wiki/Signal_(IPC))
+- [Graceful Shutdown Patterns](https://expressjs.com/en/advanced/healthcheck-graceful-shutdown.html)

--- a/log_tests/T008.1.4_StopAIServiceGraceful_TestLog.md
+++ b/log_tests/T008.1.4_StopAIServiceGraceful_TestLog.md
@@ -1,0 +1,154 @@
+# T008.1.4 Test Log: stopAIService Graceful Shutdown
+
+## Test Overview
+- **Task ID**: T008.1.4
+- **Test File**: `desktop-app/tests/main/process-manager.test.ts`
+- **New Tests Added**: 23
+- **Total Tests**: 124 (101 previous + 23 new)
+- **Framework**: Jest, ts-jest
+- **Date**: 2025-12-17
+
+## Mock Setup
+
+```typescript
+// Helper function to start service before stop tests
+async function startService(): Promise<void> {
+  await manager.startAIService();
+  expect(manager.getAIServiceStatus()).toBe(ServiceStatus.RUNNING);
+}
+
+// For force kill tests, use short timeout:
+const shortManager = new ProcessManager({ shutdownTimeoutMs: 100 });
+const shortMockProcess = createMockChildProcess();
+mockSpawn.mockImplementation(() => {
+  setTimeout(() => shortMockProcess.emit('spawn'), 10);
+  return shortMockProcess as never;
+});
+```
+
+## New Test Categories for T008.1.4
+
+### SIGTERM Signal (5 tests)
+| Test | Description |
+|------|-------------|
+| should call kill with SIGTERM when stopping | Verify kill('SIGTERM') called |
+| should send SIGTERM as first termination signal | First call is SIGTERM |
+| should set status to STOPPING before sending signal | Status change before kill |
+| should not call kill if already stopped | No kill for STOPPED state |
+| should not call kill if no process exists | Handles crashed process |
+
+### Graceful Shutdown Timeout (6 tests)
+| Test | Description |
+|------|-------------|
+| should have configurable shutdown timeout | Config has shutdownTimeoutMs |
+| should default shutdown timeout to 5000ms | Default is 5 seconds |
+| should wait for process to exit after SIGTERM | Waits for exit event |
+| should resolve Promise when process exits gracefully | Promise resolves on exit |
+| should set status to STOPPED after graceful shutdown | Status → STOPPED |
+| should clear process reference after shutdown | PID becomes undefined |
+
+### Force Kill on Timeout (5 tests)
+| Test | Description |
+|------|-------------|
+| should send SIGKILL if SIGTERM times out | SIGKILL after timeout |
+| should call SIGKILL only after SIGTERM timeout | SIGKILL is second signal |
+| should set status to STOPPED after force kill | Status → STOPPED after force |
+| should log warning when force kill is needed | console.warn called |
+| should resolve even if both signals fail | Never hangs, force cleanup |
+
+### Edge Cases (5 tests)
+| Test | Description |
+|------|-------------|
+| should handle multiple stop calls gracefully | Concurrent stops work |
+| should handle stop when process does not exist | Handles crashed process |
+| should emit statusChange event correctly | Events have correct transitions |
+| should not throw if kill() throws an error | Handles kill exceptions |
+| should clear shutdown timeout on graceful exit | Timeout is cleared |
+
+### Shutdown Configuration (2 tests)
+| Test | Description |
+|------|-------------|
+| should allow custom shutdown timeout via config | Custom timeout accepted |
+| should use custom shutdown timeout when stopping | Custom timeout used |
+
+## Test Execution
+
+```bash
+npm test -- --testPathPattern="process-manager" --verbose
+```
+
+## Results
+
+```
+Test Suites: 1 passed, 1 total
+Tests:       124 passed, 124 total
+Time:        7.986 s
+```
+
+## Key Testing Patterns
+
+### Testing graceful shutdown
+```typescript
+it('should call kill with SIGTERM when stopping', async () => {
+  await startService();
+
+  mockProcess.kill.mockImplementation(() => {
+    setTimeout(() => mockProcess.emit('exit', 0, 'SIGTERM'), 50);
+    return true;
+  });
+
+  await manager.stopAIService();
+
+  expect(mockProcess.kill).toHaveBeenCalledWith('SIGTERM');
+});
+```
+
+### Testing force kill with short timeout
+```typescript
+it('should send SIGKILL if SIGTERM times out', async () => {
+  const shortManager = new ProcessManager({ shutdownTimeoutMs: 100 });
+  const shortMockProcess = createMockChildProcess();
+  mockSpawn.mockImplementation(() => {
+    setTimeout(() => shortMockProcess.emit('spawn'), 10);
+    return shortMockProcess as never;
+  });
+
+  await shortManager.startAIService();
+
+  // SIGTERM doesn't trigger exit (hung process)
+  shortMockProcess.kill.mockImplementation((signal: string) => {
+    if (signal === 'SIGKILL') {
+      shortMockProcess.emit('exit', null, 'SIGKILL');
+    }
+    return true;
+  });
+
+  await shortManager.stopAIService();
+
+  expect(shortMockProcess.kill).toHaveBeenCalledWith('SIGKILL');
+});
+```
+
+### Testing error handling
+```typescript
+it('should not throw if kill() throws an error', async () => {
+  await startService();
+
+  mockProcess.kill.mockImplementation(() => {
+    throw new Error('Process already terminated');
+  });
+
+  // Should not throw
+  await expect(manager.stopAIService()).resolves.toBeUndefined();
+
+  expect(manager.getAIServiceStatus()).toBe(ServiceStatus.STOPPED);
+});
+```
+
+## Notes on Test Design
+
+1. **Short timeouts for force kill tests**: Using `shutdownTimeoutMs: 100` allows tests to run quickly without waiting for the full 5 second default timeout.
+
+2. **Avoiding fake timers with startAIService**: The `startAIService` method uses real timers for the spawn event, so we use short real timeouts instead of mixing fake and real timers.
+
+3. **Synchronous exit events**: For simple tests, emitting exit synchronously from kill mock works well. For tests checking STOPPING state, use `setTimeout` with small delay.

--- a/specs/001-windows-native-ai/tasks.md
+++ b/specs/001-windows-native-ai/tasks.md
@@ -672,10 +672,15 @@
     - Added: emitError() for error event emission
     - Test: 22 new tests (101 total) - all pass
     - Logs: `log_files/T008.1.3_*`, `log_tests/T008.1.3_*`, `log_learn/T008.1.3_*`
-  - [ ] T008.1.4 Implement `stopAIService()` method
-    - [ ] T008.1.4.1 Send SIGTERM to process
-    - [ ] T008.1.4.2 Wait for graceful shutdown (5s timeout)
-    - [ ] T008.1.4.3 Force kill if timeout exceeded
+  - [x] T008.1.4 Implement `stopAIService()` method ✅ *Completed 2025-12-17*
+    - [x] T008.1.4.1 Send SIGTERM to process
+    - [x] T008.1.4.2 Wait for graceful shutdown (5s timeout)
+    - [x] T008.1.4.3 Force kill with SIGKILL if timeout exceeded
+    - Added: shutdownTimeoutMs config (5s default)
+    - Added: Double timeout pattern (graceful + SIGKILL grace period)
+    - Added: Error handling for already-dead processes
+    - Test: 23 new tests (124 total) - all pass
+    - Logs: `log_files/T008.1.4_*`, `log_tests/T008.1.4_*`, `log_learn/T008.1.4_*`
   - [ ] T008.1.5 Implement `restartAIService()` method
   - [ ] T008.1.6 Implement health check polling with retry
 


### PR DESCRIPTION
- Send SIGTERM first for graceful termination
- Wait up to 5s (configurable) for process to exit
- Force kill with SIGKILL if timeout exceeded
- Add shutdownTimeoutMs config option (default: 5000ms)
- Handle edge cases: already dead process, kill errors
- Add double timeout pattern (graceful + SIGKILL grace)
- 23 new tests (124 total), all passing