### PR TITLE
feat(T008.2.1): implement startBridgeService with dotnet process spaw…

### DIFF
--- a/desktop-app/src/main/process-manager.ts
+++ b/desktop-app/src/main/process-manager.ts
@@ -282,6 +282,19 @@ export class ProcessManager {
     return process.platform === 'win32' ? 'python' : 'python3';
   }
 
+  /**
+   * Get the path to the dotnet executable (T008.2.1)
+   * @returns Path to dotnet executable
+   */
+  getDotnetPath(): string {
+    if (app.isPackaged) {
+      // In production, use bundled dotnet runtime
+      return path.join(process.resourcesPath, 'dotnet', 'dotnet.exe');
+    }
+    // In development, use system dotnet
+    return 'dotnet';
+  }
+
   // ===========================================
   // T008.1.2: Error Handling Methods
   // ===========================================
@@ -689,6 +702,7 @@ export class ProcessManager {
 
   /**
    * Start the Windows Bridge Service (.NET)
+   * T008.2.1: Real process spawning implementation
    * @returns Promise that resolves when service is started
    */
   async startBridgeService(): Promise<void> {
@@ -700,14 +714,133 @@ export class ProcessManager {
     this.updateStatus('bridge', ServiceStatus.STARTING);
     console.log('Starting Bridge Service...');
 
-    // TODO: Implement actual process spawning in T008.2.1
-    // This is a stub that simulates successful start
-    return new Promise((resolve) => {
-      setTimeout(() => {
+    return new Promise((resolve, reject) => {
+      // T008.2.1: Real process spawning implementation
+      const dotnetPath = this.getDotnetPath();
+      const bridgeServicePath = this.getBridgeServicePath();
+      const dllPath = path.join(bridgeServicePath, 'WindowsBridge.dll');
+
+      const args = [
+        dllPath,
+        '--urls', `http://127.0.0.1:${this.config.bridgeServicePort}`,
+      ];
+
+      const spawnOptions = {
+        cwd: bridgeServicePath,
+        shell: false,
+        stdio: ['ignore', 'pipe', 'pipe'] as const,
+      };
+
+      // Spawn the process
+      this.bridgeServiceProcess = spawn(dotnetPath, args, spawnOptions);
+
+      // Setup timeout
+      const timeoutId = setTimeout(() => {
+        if (this.bridgeServiceStatus === ServiceStatus.STARTING) {
+          const error = new Error(`Bridge Service startup timeout after ${this.config.startupTimeoutMs}ms`);
+          this.setError('bridge', error.message);
+          this.updateStatus('bridge', ServiceStatus.ERROR);
+          this.emitBridgeError(error);
+          reject(error);
+        }
+      }, this.config.startupTimeoutMs);
+
+      // Handle spawn event (process started successfully)
+      this.bridgeServiceProcess.on('spawn', () => {
+        clearTimeout(timeoutId);
         this.updateStatus('bridge', ServiceStatus.RUNNING);
-        console.log('Bridge Service started (stub)');
+        console.log(`Bridge Service started (PID: ${this.bridgeServiceProcess?.pid})`);
         resolve();
-      }, 100);
+      });
+
+      // Handle error event (failed to spawn)
+      this.bridgeServiceProcess.on('error', (error: Error) => {
+        clearTimeout(timeoutId);
+        this.setError('bridge', error.message);
+        this.updateStatus('bridge', ServiceStatus.ERROR);
+        this.emitBridgeError(error);
+        reject(error);
+      });
+
+      // Handle exit event (process terminated)
+      this.bridgeServiceProcess.on('exit', (code: number | null, signal: string | null) => {
+        clearTimeout(timeoutId);
+
+        if (this.bridgeServiceStatus === ServiceStatus.STOPPING) {
+          // Normal shutdown
+          this.updateStatus('bridge', ServiceStatus.STOPPED);
+        } else if (code !== 0) {
+          // Abnormal exit
+          const errorMsg = `Bridge Service exited with code ${code}${signal ? ` (signal: ${signal})` : ''}`;
+          this.setError('bridge', errorMsg);
+          this.updateStatus('bridge', ServiceStatus.ERROR);
+        } else {
+          // Clean exit while running (unexpected)
+          this.updateStatus('bridge', ServiceStatus.STOPPED);
+        }
+
+        this.bridgeServiceProcess = null;
+      });
+
+      // Capture stdout
+      if (this.bridgeServiceProcess.stdout) {
+        this.bridgeServiceProcess.stdout.on('data', (data: Buffer) => {
+          const message = data.toString().trim();
+          if (message) {
+            this.addBridgeLog('stdout', message);
+          }
+        });
+      }
+
+      // Capture stderr
+      if (this.bridgeServiceProcess.stderr) {
+        this.bridgeServiceProcess.stderr.on('data', (data: Buffer) => {
+          const message = data.toString().trim();
+          if (message) {
+            this.addBridgeLog('stderr', message);
+          }
+        });
+      }
+    });
+  }
+
+  /**
+   * Add a log entry for the bridge service (T008.2.1)
+   * @param level - Log level (stdout or stderr)
+   * @param message - Log message
+   */
+  private addBridgeLog(level: 'stdout' | 'stderr', message: string): void {
+    const entry: ProcessLogEntry = {
+      timestamp: new Date(),
+      level,
+      message,
+    };
+
+    this.bridgeProcessLogs.push(entry);
+
+    // Trim logs if exceeding max
+    if (this.bridgeProcessLogs.length > this.MAX_LOG_ENTRIES) {
+      this.bridgeProcessLogs.shift();
+    }
+
+    // Also log to console
+    if (level === 'stdout') {
+      console.log(`[Bridge Service] ${message}`);
+    } else {
+      console.error(`[Bridge Service ERROR] ${message}`);
+    }
+  }
+
+  /**
+   * Emit error event for bridge service (T008.2.1)
+   * @param error - Error object
+   */
+  private emitBridgeError(error: Error): void {
+    this.emit('error', {
+      service: 'bridge',
+      status: ServiceStatus.ERROR,
+      previousStatus: ServiceStatus.STARTING,
+      timestamp: new Date(),
     });
   }
 

--- a/desktop-app/tests/main/process-manager.test.ts
+++ b/desktop-app/tests/main/process-manager.test.ts
@@ -64,9 +64,11 @@ describe('ProcessManager', () => {
     // Setup mock process for all tests
     mockProcess = createMockChildProcess();
     // Auto-emit spawn event after a short delay to simulate successful start
+    // T008.2.1: Create new mock process for each spawn call to support multiple services
     mockSpawn.mockImplementation(() => {
-      setTimeout(() => mockProcess.emit('spawn'), 10);
-      return mockProcess as never;
+      const proc = createMockChildProcess();
+      setTimeout(() => proc.emit('spawn'), 10);
+      return proc as never;
     });
     manager = new ProcessManager();
   });
@@ -2281,6 +2283,378 @@ describe('ProcessManager Health Check Polling (T008.1.6)', () => {
       });
 
       expect(customManager.getConfig().healthCheckRetries).toBe(5);
+    });
+  });
+});
+
+// ===========================================
+// T008.2.1 - Bridge Service Process Spawning Tests
+// ===========================================
+
+describe('ProcessManager Bridge Service (T008.2.1)', () => {
+  let manager: ProcessManager;
+  let mockProcess: ReturnType<typeof createMockChildProcess>;
+  const mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    manager = new ProcessManager();
+    mockProcess = createMockChildProcess();
+    mockSpawn.mockImplementation(() => {
+      setTimeout(() => mockProcess.emit('spawn'), 10);
+      return mockProcess as never;
+    });
+  });
+
+  // ===========================================
+  // T008.2.1.1 - Process Spawning
+  // ===========================================
+
+  describe('Process Spawning', () => {
+    it('should spawn dotnet process for Bridge service', async () => {
+      await manager.startBridgeService();
+
+      expect(mockSpawn).toHaveBeenCalled();
+      const [command] = mockSpawn.mock.calls[0];
+      expect(command).toContain('dotnet');
+    });
+
+    it('should use correct arguments for dotnet process', async () => {
+      await manager.startBridgeService();
+
+      expect(mockSpawn).toHaveBeenCalled();
+      const [, args] = mockSpawn.mock.calls[0];
+      // Should run the WindowsBridge.dll
+      expect(args).toContainEqual(expect.stringContaining('WindowsBridge.dll'));
+    });
+
+    it('should use correct port from config', async () => {
+      await manager.startBridgeService();
+
+      expect(mockSpawn).toHaveBeenCalled();
+      const [, args] = mockSpawn.mock.calls[0];
+      const config = manager.getConfig();
+      expect(args.join(' ')).toContain(String(config.bridgeServicePort));
+    });
+
+    it('should set correct working directory', async () => {
+      await manager.startBridgeService();
+
+      expect(mockSpawn).toHaveBeenCalled();
+      const [, , options] = mockSpawn.mock.calls[0];
+      expect(options).toHaveProperty('cwd');
+      expect(options.cwd).toContain('windows-bridge');
+    });
+
+    it('should set shell option to false', async () => {
+      await manager.startBridgeService();
+
+      expect(mockSpawn).toHaveBeenCalled();
+      const [, , options] = mockSpawn.mock.calls[0];
+      expect(options).toHaveProperty('shell', false);
+    });
+
+    it('should configure stdio for process output capture', async () => {
+      await manager.startBridgeService();
+
+      expect(mockSpawn).toHaveBeenCalled();
+      const [, , options] = mockSpawn.mock.calls[0];
+      expect(options).toHaveProperty('stdio');
+      expect(options.stdio).toEqual(['ignore', 'pipe', 'pipe']);
+    });
+  });
+
+  // ===========================================
+  // T008.2.1.2 - Status Transitions
+  // ===========================================
+
+  describe('Status Transitions', () => {
+    it('should transition from STOPPED to STARTING', async () => {
+      expect(manager.getBridgeServiceStatus()).toBe(ServiceStatus.STOPPED);
+
+      const startPromise = manager.startBridgeService();
+
+      expect(manager.getBridgeServiceStatus()).toBe(ServiceStatus.STARTING);
+
+      await startPromise;
+    });
+
+    it('should transition from STARTING to RUNNING on spawn', async () => {
+      await manager.startBridgeService();
+
+      expect(manager.getBridgeServiceStatus()).toBe(ServiceStatus.RUNNING);
+    });
+
+    it('should not start if already running', async () => {
+      await manager.startBridgeService();
+      expect(manager.getBridgeServiceStatus()).toBe(ServiceStatus.RUNNING);
+
+      mockSpawn.mockClear();
+      await manager.startBridgeService();
+
+      expect(mockSpawn).not.toHaveBeenCalled();
+    });
+
+    it('should emit statusChange event on STARTING', async () => {
+      const listener = jest.fn();
+      manager.on('statusChange', listener);
+
+      const startPromise = manager.startBridgeService();
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          service: 'bridge',
+          status: ServiceStatus.STARTING,
+          previousStatus: ServiceStatus.STOPPED,
+        })
+      );
+
+      await startPromise;
+    });
+
+    it('should emit statusChange event on RUNNING', async () => {
+      const listener = jest.fn();
+      manager.on('statusChange', listener);
+
+      await manager.startBridgeService();
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          service: 'bridge',
+          status: ServiceStatus.RUNNING,
+          previousStatus: ServiceStatus.STARTING,
+        })
+      );
+    });
+  });
+
+  // ===========================================
+  // T008.2.1.3 - Error Handling
+  // ===========================================
+
+  describe('Error Handling', () => {
+    it('should transition to ERROR status on spawn error', async () => {
+      mockSpawn.mockImplementation(() => {
+        setTimeout(() => mockProcess.emit('error', new Error('Spawn failed')), 10);
+        return mockProcess as never;
+      });
+
+      await expect(manager.startBridgeService()).rejects.toThrow('Spawn failed');
+      expect(manager.getBridgeServiceStatus()).toBe(ServiceStatus.ERROR);
+    });
+
+    it('should set lastError on spawn failure', async () => {
+      mockSpawn.mockImplementation(() => {
+        setTimeout(() => mockProcess.emit('error', new Error('ENOENT: dotnet not found')), 10);
+        return mockProcess as never;
+      });
+
+      await expect(manager.startBridgeService()).rejects.toThrow();
+
+      expect(manager.getLastError('bridge')).toBe('ENOENT: dotnet not found');
+    });
+
+    it('should emit error event on spawn failure', async () => {
+      const errorListener = jest.fn();
+      manager.on('error', errorListener);
+
+      mockSpawn.mockImplementation(() => {
+        setTimeout(() => mockProcess.emit('error', new Error('Failed')), 10);
+        return mockProcess as never;
+      });
+
+      await expect(manager.startBridgeService()).rejects.toThrow();
+
+      expect(errorListener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          service: 'bridge',
+          status: ServiceStatus.ERROR,
+        })
+      );
+    });
+
+    it('should handle exit before spawn event', async () => {
+      mockSpawn.mockImplementation(() => {
+        setTimeout(() => mockProcess.emit('exit', 1, null), 10);
+        return mockProcess as never;
+      });
+
+      // Process exits immediately without spawning
+      const startPromise = manager.startBridgeService();
+
+      // Wait for the exit and timeout
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      // Check status - should be error
+      expect(manager.getBridgeServiceStatus()).toBe(ServiceStatus.ERROR);
+    });
+  });
+
+  // ===========================================
+  // T008.2.1.4 - Startup Timeout
+  // ===========================================
+
+  describe('Startup Timeout', () => {
+    it('should timeout if spawn event not received', async () => {
+      // Create manager with very short timeout
+      const shortManager = new ProcessManager({ startupTimeoutMs: 100 });
+      const shortMockProcess = createMockChildProcess();
+
+      mockSpawn.mockImplementation(() => {
+        // Never emit spawn event
+        return shortMockProcess as never;
+      });
+
+      await expect(shortManager.startBridgeService()).rejects.toThrow(/timeout/i);
+      expect(shortManager.getBridgeServiceStatus()).toBe(ServiceStatus.ERROR);
+    });
+
+    it('should use startupTimeoutMs from config', async () => {
+      const customManager = new ProcessManager({ startupTimeoutMs: 50 });
+      const customMockProcess = createMockChildProcess();
+
+      mockSpawn.mockImplementation(() => {
+        // Never emit spawn - will timeout
+        return customMockProcess as never;
+      });
+
+      const startTime = Date.now();
+      await expect(customManager.startBridgeService()).rejects.toThrow();
+      const elapsed = Date.now() - startTime;
+
+      // Should timeout around 50ms (with some tolerance)
+      expect(elapsed).toBeGreaterThanOrEqual(40);
+      expect(elapsed).toBeLessThan(500);
+    });
+  });
+
+  // ===========================================
+  // T008.2.1.5 - Process Output Logging
+  // ===========================================
+
+  describe('Process Output Logging', () => {
+    it('should capture stdout output', async () => {
+      await manager.startBridgeService();
+
+      // Emit some stdout
+      mockProcess.stdout.emit('data', Buffer.from('Bridge service started\n'));
+
+      const logs = manager.getProcessLogs('bridge');
+      expect(logs.length).toBeGreaterThan(0);
+      expect(logs[logs.length - 1].level).toBe('stdout');
+      expect(logs[logs.length - 1].message).toContain('Bridge service started');
+    });
+
+    it('should capture stderr output', async () => {
+      await manager.startBridgeService();
+
+      // Emit some stderr
+      mockProcess.stderr.emit('data', Buffer.from('Warning: something\n'));
+
+      const logs = manager.getProcessLogs('bridge');
+      expect(logs.length).toBeGreaterThan(0);
+      const stderrLogs = logs.filter(l => l.level === 'stderr');
+      expect(stderrLogs.length).toBeGreaterThan(0);
+    });
+
+    it('should include timestamp in log entries', async () => {
+      await manager.startBridgeService();
+
+      mockProcess.stdout.emit('data', Buffer.from('Test output\n'));
+
+      const logs = manager.getProcessLogs('bridge');
+      expect(logs.length).toBeGreaterThan(0);
+      expect(logs[logs.length - 1].timestamp).toBeInstanceOf(Date);
+    });
+  });
+
+  // ===========================================
+  // T008.2.1.6 - Process Exit Handling
+  // ===========================================
+
+  describe('Process Exit Handling', () => {
+    it('should update status on process exit with error code', async () => {
+      await manager.startBridgeService();
+      expect(manager.getBridgeServiceStatus()).toBe(ServiceStatus.RUNNING);
+
+      // Simulate process crash
+      mockProcess.emit('exit', 1, null);
+
+      expect(manager.getBridgeServiceStatus()).toBe(ServiceStatus.ERROR);
+    });
+
+    it('should set lastError on non-zero exit code', async () => {
+      await manager.startBridgeService();
+
+      mockProcess.emit('exit', 1, null);
+
+      expect(manager.getLastError('bridge')).toContain('exited with code 1');
+    });
+
+    it('should include signal in error message if present', async () => {
+      await manager.startBridgeService();
+
+      mockProcess.emit('exit', null, 'SIGTERM');
+
+      expect(manager.getLastError('bridge')).toContain('SIGTERM');
+    });
+
+    it('should clean up process reference on exit', async () => {
+      await manager.startBridgeService();
+
+      mockProcess.emit('exit', 0, null);
+
+      expect(manager.getBridgeServiceStatus()).toBe(ServiceStatus.STOPPED);
+    });
+  });
+
+  // ===========================================
+  // T008.2.1.7 - Uptime and PID Tracking
+  // ===========================================
+
+  describe('Uptime and PID Tracking', () => {
+    it('should track PID after successful start', async () => {
+      await manager.startBridgeService();
+
+      const health = await manager.checkHealth('bridge');
+      expect(health.pid).toBe(12345);
+    });
+
+    it('should track uptime after successful start', async () => {
+      await manager.startBridgeService();
+
+      // Wait a bit
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const health = await manager.checkHealth('bridge');
+      expect(health.uptime).toBeGreaterThan(0);
+    });
+
+    it('should reset uptime on stop', async () => {
+      await manager.startBridgeService();
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      // Simulate exit (stop)
+      mockProcess.emit('exit', 0, null);
+
+      const health = await manager.checkHealth('bridge');
+      expect(health.uptime).toBeUndefined();
+    });
+  });
+
+  // ===========================================
+  // T008.2.1.8 - getDotnetPath Method
+  // ===========================================
+
+  describe('getDotnetPath', () => {
+    it('should have getDotnetPath method', () => {
+      expect(manager.getDotnetPath).toBeDefined();
+      expect(typeof manager.getDotnetPath).toBe('function');
+    });
+
+    it('should return system dotnet path in development', () => {
+      const dotnetPath = manager.getDotnetPath();
+      expect(dotnetPath).toBe('dotnet');
     });
   });
 });

--- a/log_files/T008.2.1_StartBridgeService_Log.md
+++ b/log_files/T008.2.1_StartBridgeService_Log.md
@@ -1,0 +1,179 @@
+# T008.2.1 Implementation Log: Start Bridge Service
+
+## Task Overview
+- **Task ID**: T008.2.1
+- **Task Name**: Implement `startBridgeService()` method
+- **Status**: Completed
+- **Date**: 2025-12-17
+
+## Implementation Details
+
+### What Was Implemented
+
+Real process spawning for the Windows Bridge Service (.NET/ASP.NET Core):
+
+1. **getDotnetPath()**: Method to locate the dotnet executable
+2. **startBridgeService()**: Full implementation with process spawning
+3. **addBridgeLog()**: Process output logging for bridge service
+4. **emitBridgeError()**: Error event emission for bridge service
+
+### Code Changes
+
+#### 1. getDotnetPath Method
+```typescript
+getDotnetPath(): string {
+  if (app.isPackaged) {
+    // In production, use bundled dotnet runtime
+    return path.join(process.resourcesPath, 'dotnet', 'dotnet.exe');
+  }
+  // In development, use system dotnet
+  return 'dotnet';
+}
+```
+
+#### 2. startBridgeService Implementation
+```typescript
+async startBridgeService(): Promise<void> {
+  if (this.bridgeServiceStatus === ServiceStatus.RUNNING) {
+    return;
+  }
+
+  this.updateStatus('bridge', ServiceStatus.STARTING);
+
+  return new Promise((resolve, reject) => {
+    const dotnetPath = this.getDotnetPath();
+    const bridgeServicePath = this.getBridgeServicePath();
+    const dllPath = path.join(bridgeServicePath, 'WindowsBridge.dll');
+
+    const args = [
+      dllPath,
+      '--urls', `http://127.0.0.1:${this.config.bridgeServicePort}`,
+    ];
+
+    const spawnOptions = {
+      cwd: bridgeServicePath,
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'] as const,
+    };
+
+    this.bridgeServiceProcess = spawn(dotnetPath, args, spawnOptions);
+
+    // Setup timeout, spawn/error/exit handlers, stdout/stderr capture
+    // ... (similar pattern to AI service)
+  });
+}
+```
+
+#### 3. Process Output Logging
+```typescript
+private addBridgeLog(level: 'stdout' | 'stderr', message: string): void {
+  const entry: ProcessLogEntry = {
+    timestamp: new Date(),
+    level,
+    message,
+  };
+
+  this.bridgeProcessLogs.push(entry);
+
+  // Trim logs if exceeding max
+  if (this.bridgeProcessLogs.length > this.MAX_LOG_ENTRIES) {
+    this.bridgeProcessLogs.shift();
+  }
+
+  // Log to console
+  if (level === 'stdout') {
+    console.log(`[Bridge Service] ${message}`);
+  } else {
+    console.error(`[Bridge Service ERROR] ${message}`);
+  }
+}
+```
+
+### Files Modified
+- `desktop-app/src/main/process-manager.ts`
+- `desktop-app/tests/main/process-manager.test.ts`
+
+### Key Design Decisions
+
+1. **Dotnet CLI**: Uses `dotnet <dll>` pattern for running .NET Core applications
+2. **URL Configuration**: Passes `--urls` argument for port configuration
+3. **Consistent Pattern**: Same structure as AI service for maintainability
+4. **Separate Logging**: Bridge service has its own log array (`bridgeProcessLogs`)
+5. **Error Isolation**: Separate error emission method for bridge service
+
+### Test Infrastructure Update
+
+Fixed test mock setup to create new mock processes for each spawn call:
+
+```typescript
+mockSpawn.mockImplementation(() => {
+  const proc = createMockChildProcess();  // New process each time
+  setTimeout(() => proc.emit('spawn'), 10);
+  return proc as never;
+});
+```
+
+This allows testing both AI and Bridge services independently without interference.
+
+### Test Coverage
+
+#### New T008.2.1 Tests (29 tests)
+| Category | Tests |
+|----------|-------|
+| Process Spawning | 6 |
+| Status Transitions | 5 |
+| Error Handling | 4 |
+| Startup Timeout | 2 |
+| Process Output Logging | 3 |
+| Process Exit Handling | 4 |
+| Uptime and PID Tracking | 3 |
+| getDotnetPath | 2 |
+
+### Total Test Suite
+- **Previous tests**: 165 passed
+- **New T008.2.1 tests**: 29 passed
+- **Total**: 194 passed
+
+## Architecture
+
+```
+startBridgeService()
+    │
+    ├── Check if already running
+    │
+    ├── Update status to STARTING
+    │
+    ├── Get paths (dotnet, bridge dir, dll)
+    │
+    ├── Build args: [WindowsBridge.dll, --urls, http://...]
+    │
+    ├── Spawn process with stdio capture
+    │
+    ├── Setup handlers:
+    │   ├── spawn → RUNNING, resolve
+    │   ├── error → ERROR, reject
+    │   ├── exit → STOPPED/ERROR, cleanup
+    │   ├── stdout → addBridgeLog('stdout')
+    │   └── stderr → addBridgeLog('stderr')
+    │
+    └── Setup timeout → ERROR if no spawn event
+```
+
+## .NET Service Execution
+
+The Windows Bridge is a .NET Core application executed via:
+
+```bash
+dotnet /path/to/WindowsBridge.dll --urls http://127.0.0.1:5000
+```
+
+- **dotnet**: The .NET CLI (system or bundled)
+- **WindowsBridge.dll**: The compiled .NET application
+- **--urls**: ASP.NET Core hosting URL argument
+
+## Production vs Development
+
+| Environment | dotnet Path | Service Path |
+|-------------|-------------|--------------|
+| Development | System `dotnet` | `../windows-bridge` |
+| Production | `resources/dotnet/dotnet.exe` | `resources/windows-bridge` |

--- a/log_learn/T008.2.1_StartBridgeService_Guide.md
+++ b/log_learn/T008.2.1_StartBridgeService_Guide.md
@@ -1,0 +1,242 @@
+# T008.2.1 Learning Guide: Start Bridge Service
+
+## Overview
+
+This guide covers implementing process spawning for a .NET Core service from an Electron main process, following TDD principles.
+
+## Key Concepts
+
+### 1. Running .NET Core Applications
+
+.NET Core apps can be executed via the `dotnet` CLI:
+
+```bash
+dotnet /path/to/YourApp.dll [arguments]
+```
+
+For ASP.NET Core web services, use `--urls` to specify the listening address:
+
+```bash
+dotnet WindowsBridge.dll --urls http://127.0.0.1:5000
+```
+
+### 2. Development vs Production Paths
+
+In Electron apps, paths differ between development and packaged production:
+
+```typescript
+getDotnetPath(): string {
+  if (app.isPackaged) {
+    // Production: bundled runtime in resources
+    return path.join(process.resourcesPath, 'dotnet', 'dotnet.exe');
+  }
+  // Development: use system-installed dotnet
+  return 'dotnet';
+}
+```
+
+### 3. Process Spawning with spawn()
+
+Node.js `spawn()` is preferred over `exec()` for long-running processes:
+
+```typescript
+import { spawn, ChildProcess } from 'child_process';
+
+const process = spawn(command, args, {
+  cwd: workingDirectory,
+  shell: false,          // Security: don't use shell
+  stdio: ['ignore', 'pipe', 'pipe'],  // Capture stdout/stderr
+});
+```
+
+### 4. Test Mock Isolation
+
+When testing multiple services that spawn processes, each spawn call should return a fresh mock:
+
+```typescript
+// ❌ Bad: Shared mock causes interference
+mockSpawn.mockReturnValue(mockProcess);
+
+// ✅ Good: New mock per spawn call
+mockSpawn.mockImplementation(() => {
+  const proc = createMockChildProcess();
+  setTimeout(() => proc.emit('spawn'), 10);
+  return proc;
+});
+```
+
+## Code Patterns
+
+### Factory Function for Mock Processes
+
+```typescript
+function createMockChildProcess() {
+  const mockProcess = new EventEmitter() as EventEmitter & {
+    pid: number;
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: jest.Mock;
+    killed: boolean;
+  };
+  mockProcess.pid = 12345;
+  mockProcess.stdout = new EventEmitter();
+  mockProcess.stderr = new EventEmitter();
+  mockProcess.kill = jest.fn().mockImplementation(() => {
+    mockProcess.killed = true;
+    mockProcess.emit('exit', 0, null);
+    return true;
+  });
+  mockProcess.killed = false;
+  return mockProcess;
+}
+```
+
+### Service-Specific Logging
+
+Keep logs separate per service:
+
+```typescript
+private aiProcessLogs: ProcessLogEntry[] = [];
+private bridgeProcessLogs: ProcessLogEntry[] = [];
+
+getProcessLogs(service: 'ai' | 'bridge'): ProcessLogEntry[] {
+  return service === 'ai'
+    ? [...this.aiProcessLogs]
+    : [...this.bridgeProcessLogs];
+}
+```
+
+### Consistent Event Patterns
+
+Use the same event structure across services:
+
+```typescript
+private emitBridgeError(error: Error): void {
+  this.emit('error', {
+    service: 'bridge',
+    status: ServiceStatus.ERROR,
+    previousStatus: this.bridgeServiceStatus,
+    timestamp: new Date(),
+  });
+}
+```
+
+## Testing Strategies
+
+### 1. Verify Spawn Arguments
+
+```typescript
+it('should use correct arguments for dotnet process', async () => {
+  await manager.startBridgeService();
+
+  const [, args] = mockSpawn.mock.calls[0];
+  expect(args).toContainEqual(expect.stringContaining('WindowsBridge.dll'));
+  expect(args).toContain('--urls');
+});
+```
+
+### 2. Test Status Transitions
+
+```typescript
+it('should transition from STOPPED to STARTING', async () => {
+  const statusChanges: ServiceStatus[] = [];
+  manager.on('statusChange', (event) => {
+    if (event.service === 'bridge') {
+      statusChanges.push(event.status);
+    }
+  });
+
+  const startPromise = manager.startBridgeService();
+  expect(manager.getBridgeServiceStatus()).toBe(ServiceStatus.STARTING);
+
+  await startPromise;
+  expect(statusChanges).toContain(ServiceStatus.STARTING);
+});
+```
+
+### 3. Test Error Scenarios
+
+```typescript
+it('should handle spawn error', async () => {
+  mockSpawn.mockImplementation(() => {
+    const proc = createMockChildProcess();
+    setTimeout(() => proc.emit('error', new Error('Spawn failed')), 10);
+    return proc;
+  });
+
+  await expect(manager.startBridgeService()).rejects.toThrow('Spawn failed');
+  expect(manager.getBridgeServiceStatus()).toBe(ServiceStatus.ERROR);
+});
+```
+
+### 4. Test Timeout Handling
+
+```typescript
+it('should timeout if spawn event not received', async () => {
+  const shortManager = new ProcessManager({ startupTimeoutMs: 100 });
+
+  mockSpawn.mockImplementation(() => {
+    return createMockChildProcess();  // Never emits 'spawn'
+  });
+
+  await expect(shortManager.startBridgeService()).rejects.toThrow(/timeout/i);
+});
+```
+
+## Common Pitfalls
+
+### 1. Mock Process Sharing
+
+**Problem**: Multiple services use the same mock, causing event interference.
+
+**Solution**: Create new mock for each spawn call.
+
+### 2. Forgetting to Clear Timeouts
+
+**Problem**: Timeout fires after successful start, causing unexpected behavior.
+
+**Solution**: Always clear startup timeout on success or failure:
+
+```typescript
+const timeoutId = setTimeout(() => { /* timeout logic */ }, timeout);
+
+process.on('spawn', () => {
+  clearTimeout(timeoutId);
+  resolve();
+});
+
+process.on('error', (err) => {
+  clearTimeout(timeoutId);
+  reject(err);
+});
+```
+
+### 3. Platform-Specific Paths
+
+**Problem**: Hardcoded paths break on different platforms.
+
+**Solution**: Use `path.join()` and platform detection:
+
+```typescript
+const executable = process.platform === 'win32'
+  ? 'dotnet.exe'
+  : 'dotnet';
+```
+
+## Best Practices
+
+1. **Consistent Patterns**: Use the same structure across similar services (AI and Bridge follow identical patterns)
+
+2. **Separate State**: Each service has its own status, process reference, and logs
+
+3. **Idempotent Operations**: Check if already running before starting
+
+4. **Comprehensive Events**: Emit events for all state changes
+
+5. **Resource Cleanup**: Clear process references and logs on exit
+
+## Related Tasks
+
+- T008.1.3: startAIService (same pattern for Python)
+- T008.2.2: stopBridgeService (graceful shutdown)
+- T008.2.3: Bridge health check polling

--- a/log_tests/T008.2.1_StartBridgeService_TestLog.md
+++ b/log_tests/T008.2.1_StartBridgeService_TestLog.md
@@ -1,0 +1,209 @@
+# T008.2.1 Test Log: Start Bridge Service
+
+## Test Overview
+- **Task ID**: T008.2.1
+- **Test File**: `desktop-app/tests/main/process-manager.test.ts`
+- **New Tests Added**: 29
+- **Total Tests**: 194 (165 previous + 29 new)
+- **Framework**: Jest, ts-jest
+- **Date**: 2025-12-17
+
+## Test Categories
+
+### Process Spawning (6 tests)
+| Test | Description |
+|------|-------------|
+| should spawn dotnet process for Bridge service | Verifies spawn is called with dotnet |
+| should use correct arguments for dotnet process | Args include WindowsBridge.dll |
+| should use correct port from config | Uses bridgeServicePort |
+| should set correct working directory | CWD is windows-bridge dir |
+| should set shell option to false | shell: false for security |
+| should configure stdio for process output capture | stdio: ['ignore', 'pipe', 'pipe'] |
+
+### Status Transitions (5 tests)
+| Test | Description |
+|------|-------------|
+| should transition from STOPPED to STARTING | Initial state change |
+| should transition from STARTING to RUNNING on spawn | After spawn event |
+| should not start if already running | Idempotent start |
+| should emit statusChange event on STARTING | Event emission test |
+| should emit statusChange event on RUNNING | Event emission test |
+
+### Error Handling (4 tests)
+| Test | Description |
+|------|-------------|
+| should transition to ERROR status on spawn error | Error state handling |
+| should set lastError on spawn failure | Error message storage |
+| should emit error event on spawn failure | Error event emission |
+| should handle exit before spawn event | Early exit handling |
+
+### Startup Timeout (2 tests)
+| Test | Description |
+|------|-------------|
+| should timeout if spawn event not received | Timeout handling |
+| should use startupTimeoutMs from config | Config respect |
+
+### Process Output Logging (3 tests)
+| Test | Description |
+|------|-------------|
+| should capture stdout output | stdout capture |
+| should capture stderr output | stderr capture |
+| should include timestamp in log entries | Log entry format |
+
+### Process Exit Handling (4 tests)
+| Test | Description |
+|------|-------------|
+| should update status on process exit with error code | Exit handling |
+| should set lastError on non-zero exit code | Error tracking |
+| should include signal in error message if present | Signal handling |
+| should clean up process reference on exit | Resource cleanup |
+
+### Uptime and PID Tracking (3 tests)
+| Test | Description |
+|------|-------------|
+| should track PID after successful start | PID tracking |
+| should track uptime after successful start | Uptime tracking |
+| should reset uptime on stop | Cleanup verification |
+
+### getDotnetPath (2 tests)
+| Test | Description |
+|------|-------------|
+| should have getDotnetPath method | Method existence |
+| should return system dotnet path in development | Path resolution |
+
+## Test Execution
+
+```bash
+npm test -- --testPathPattern="process-manager" --testNamePattern="T008.2.1"
+```
+
+## Results
+
+```
+Test Suites: 1 passed, 1 total
+Tests:       194 passed, 194 total
+Time:        9.13 s
+```
+
+## Key Test Patterns
+
+### Multiple Service Mock Support
+
+The test infrastructure was updated to create new mock processes for each spawn call:
+
+```typescript
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockProcess = createMockChildProcess();
+  // Create new mock process for each spawn call
+  mockSpawn.mockImplementation(() => {
+    const proc = createMockChildProcess();
+    setTimeout(() => proc.emit('spawn'), 10);
+    return proc as never;
+  });
+  manager = new ProcessManager();
+});
+```
+
+This ensures AI and Bridge services don't interfere with each other in tests.
+
+### Process Spawning Tests
+
+```typescript
+it('should spawn dotnet process for Bridge service', async () => {
+  await manager.startBridgeService();
+
+  expect(mockSpawn).toHaveBeenCalled();
+  const [command] = mockSpawn.mock.calls[0];
+  expect(command).toContain('dotnet');
+});
+
+it('should use correct arguments for dotnet process', async () => {
+  await manager.startBridgeService();
+
+  const [, args] = mockSpawn.mock.calls[0];
+  expect(args).toContainEqual(expect.stringContaining('WindowsBridge.dll'));
+});
+```
+
+### Error Handling Tests
+
+```typescript
+it('should transition to ERROR status on spawn error', async () => {
+  mockSpawn.mockImplementation(() => {
+    setTimeout(() => mockProcess.emit('error', new Error('Spawn failed')), 10);
+    return mockProcess as never;
+  });
+
+  await expect(manager.startBridgeService()).rejects.toThrow('Spawn failed');
+  expect(manager.getBridgeServiceStatus()).toBe(ServiceStatus.ERROR);
+});
+```
+
+### Timeout Tests
+
+```typescript
+it('should timeout if spawn event not received', async () => {
+  const shortManager = new ProcessManager({ startupTimeoutMs: 100 });
+  const shortMockProcess = createMockChildProcess();
+
+  mockSpawn.mockImplementation(() => {
+    // Never emit spawn event
+    return shortMockProcess as never;
+  });
+
+  await expect(shortManager.startBridgeService()).rejects.toThrow(/timeout/i);
+  expect(shortManager.getBridgeServiceStatus()).toBe(ServiceStatus.ERROR);
+});
+```
+
+### Process Output Tests
+
+```typescript
+it('should capture stdout output', async () => {
+  await manager.startBridgeService();
+
+  mockProcess.stdout.emit('data', Buffer.from('Bridge service started\n'));
+
+  const logs = manager.getProcessLogs('bridge');
+  expect(logs.length).toBeGreaterThan(0);
+  expect(logs[logs.length - 1].level).toBe('stdout');
+  expect(logs[logs.length - 1].message).toContain('Bridge service started');
+});
+```
+
+## Helper Functions
+
+```typescript
+function createMockChildProcess() {
+  const mockProcess = new EventEmitter() as EventEmitter & {
+    pid: number;
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: jest.Mock;
+    killed: boolean;
+  };
+  mockProcess.pid = 12345;
+  mockProcess.stdout = new EventEmitter();
+  mockProcess.stderr = new EventEmitter();
+  mockProcess.kill = jest.fn().mockImplementation(() => {
+    mockProcess.killed = true;
+    mockProcess.emit('exit', 0, null);
+    return true;
+  });
+  mockProcess.killed = false;
+  return mockProcess;
+}
+```
+
+## Notes
+
+1. **Mock Isolation**: Each spawn call creates a new mock process to prevent cross-service interference
+
+2. **Consistent Pattern**: Tests follow the same pattern as AI service tests for consistency
+
+3. **Port Verification**: Tests verify the correct port (bridgeServicePort: 5000) is used
+
+4. **Path Verification**: Tests verify the correct working directory contains "windows-bridge"
+
+5. **getDotnetPath**: Returns "dotnet" in development, bundled path in production

--- a/specs/001-windows-native-ai/tasks.md
+++ b/specs/001-windows-native-ai/tasks.md
@@ -707,7 +707,12 @@
     - Logs: `log_files/T008.1.6_*`, `log_tests/T008.1.6_*`, `log_learn/T008.1.6_*`
 
 - [ ] **T008.2** Implement Windows Bridge process management
-  - [ ] T008.2.1 Implement `startBridgeService()` method
+  - [x] T008.2.1 Implement `startBridgeService()` method
+    - Implemented: getDotnetPath(), startBridgeService(), addBridgeLog(), emitBridgeError()
+    - Pattern: Uses `dotnet <dll> --urls http://...` for .NET Core execution
+    - Test infrastructure: Updated mock to create new process per spawn call
+    - Test: 29 new tests (194 total) - all pass
+    - Logs: `log_files/T008.2.1_*`, `log_tests/T008.2.1_*`, `log_learn/T008.2.1_*`
   - [ ] T008.2.2 Implement `stopBridgeService()` method
   - [ ] T008.2.3 Implement health check polling
 


### PR DESCRIPTION
…ning

- Add getDotnetPath() for dev/production environment handling
- Implement startBridgeService() with full process lifecycle
- Add addBridgeLog() and emitBridgeError() helpers
- Update test infrastructure to create new mock process per spawn call
- 29 new tests (194 total), all passing