### PR TITLE
feat(T010.2): implement useServiceStatus hook with polling and events

### DIFF
--- a/desktop-app/src/renderer/hooks/useServiceStatus.ts
+++ b/desktop-app/src/renderer/hooks/useServiceStatus.ts
@@ -1,0 +1,194 @@
+/**
+ * useServiceStatus Hook
+ *
+ * Custom React hook for managing AI and Bridge service status.
+ * Polls services periodically and listens for status change events.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { ServiceStatus } from '../types';
+
+/**
+ * Polling interval in milliseconds (5 seconds)
+ */
+const POLL_INTERVAL = 5000;
+
+/**
+ * Response from ai:get-status IPC call
+ */
+interface AIStatusResponse {
+  status: ServiceStatus;
+  running: boolean;
+}
+
+/**
+ * Response from bridge:check-health IPC call
+ */
+interface BridgeHealthResponse {
+  status: ServiceStatus;
+  healthy: boolean;
+  company?: string;
+}
+
+/**
+ * Status change event data
+ */
+interface StatusChangeEvent {
+  status: ServiceStatus;
+  previousStatus?: ServiceStatus;
+}
+
+/**
+ * Return type for useServiceStatus hook
+ */
+export interface UseServiceStatusResult {
+  /** Current AI service status */
+  aiStatus: ServiceStatus;
+  /** Current Bridge service status */
+  bridgeStatus: ServiceStatus;
+  /** Connected company name (if available) */
+  companyName: string | undefined;
+  /** Whether initial status fetch is in progress */
+  isLoading: boolean;
+  /** Manually refresh status */
+  refresh: () => void;
+}
+
+/**
+ * Hook for managing service status with polling and event-based updates.
+ *
+ * @example
+ * ```tsx
+ * function StatusDisplay() {
+ *   const { aiStatus, bridgeStatus, companyName, isLoading } = useServiceStatus();
+ *
+ *   if (isLoading) return <div>Loading...</div>;
+ *
+ *   return (
+ *     <StatusBar
+ *       aiStatus={aiStatus}
+ *       bridgeStatus={bridgeStatus}
+ *       companyName={companyName}
+ *     />
+ *   );
+ * }
+ * ```
+ */
+export function useServiceStatus(): UseServiceStatusResult {
+  // Status state - start with 'starting' while we fetch
+  const [aiStatus, setAiStatus] = useState<ServiceStatus>('starting');
+  const [bridgeStatus, setBridgeStatus] = useState<ServiceStatus>('starting');
+  const [companyName, setCompanyName] = useState<string | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Track if component is mounted to avoid state updates after unmount
+  const isMountedRef = useRef(true);
+
+  // Reference to polling interval
+  const pollIntervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  /**
+   * Fetch current status from both services
+   */
+  const fetchStatus = useCallback(async () => {
+    if (!isMountedRef.current) return;
+
+    try {
+      // Fetch AI status
+      const aiResponse = await window.electronAPI.invoke('ai:get-status') as AIStatusResponse | null;
+      if (isMountedRef.current && aiResponse) {
+        setAiStatus(aiResponse.status);
+      }
+    } catch (error) {
+      console.error('Failed to fetch AI status:', error);
+      if (isMountedRef.current) {
+        setAiStatus('error');
+      }
+    }
+
+    try {
+      // Fetch Bridge status
+      const bridgeResponse = await window.electronAPI.invoke('bridge:check-health') as BridgeHealthResponse | null;
+      if (isMountedRef.current && bridgeResponse) {
+        setBridgeStatus(bridgeResponse.status);
+        if (bridgeResponse.company) {
+          setCompanyName(bridgeResponse.company);
+        }
+      }
+    } catch (error) {
+      console.error('Failed to fetch Bridge status:', error);
+      if (isMountedRef.current) {
+        setBridgeStatus('error');
+      }
+    }
+
+    if (isMountedRef.current) {
+      setIsLoading(false);
+    }
+  }, []);
+
+  /**
+   * Handle AI status change event
+   */
+  const handleAiStatusChange = useCallback((data: StatusChangeEvent) => {
+    if (isMountedRef.current) {
+      setAiStatus(data.status);
+    }
+  }, []);
+
+  /**
+   * Handle Bridge status change event
+   */
+  const handleBridgeStatusChange = useCallback((data: StatusChangeEvent) => {
+    if (isMountedRef.current) {
+      setBridgeStatus(data.status);
+    }
+  }, []);
+
+  /**
+   * Manual refresh function
+   */
+  const refresh = useCallback(() => {
+    fetchStatus();
+  }, [fetchStatus]);
+
+  // Setup polling and event listeners on mount
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    // Initial fetch
+    fetchStatus();
+
+    // Setup polling
+    pollIntervalRef.current = setInterval(fetchStatus, POLL_INTERVAL);
+
+    // Subscribe to status change events
+    window.electronAPI.on('ai:status-changed', handleAiStatusChange);
+    window.electronAPI.on('bridge:status-changed', handleBridgeStatusChange);
+
+    // Cleanup on unmount
+    return () => {
+      isMountedRef.current = false;
+
+      // Clear polling interval
+      if (pollIntervalRef.current) {
+        clearInterval(pollIntervalRef.current);
+        pollIntervalRef.current = null;
+      }
+
+      // Unsubscribe from events
+      window.electronAPI.removeListener('ai:status-changed', handleAiStatusChange);
+      window.electronAPI.removeListener('bridge:status-changed', handleBridgeStatusChange);
+    };
+  }, [fetchStatus, handleAiStatusChange, handleBridgeStatusChange]);
+
+  return {
+    aiStatus,
+    bridgeStatus,
+    companyName,
+    isLoading,
+    refresh,
+  };
+}
+
+export default useServiceStatus;

--- a/desktop-app/tests/renderer/hooks/useServiceStatus.test.ts
+++ b/desktop-app/tests/renderer/hooks/useServiceStatus.test.ts
@@ -1,0 +1,380 @@
+/**
+ * T010.2.1 useServiceStatus Hook Tests
+ *
+ * Tests for the status polling hook that manages AI and Bridge service status.
+ */
+
+import { renderHook, act, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// Mock the electronAPI before importing the hook
+const mockInvoke = jest.fn();
+const mockOn = jest.fn();
+const mockRemoveListener = jest.fn();
+
+const mockElectronAPI = {
+  invoke: mockInvoke,
+  on: mockOn,
+  removeListener: mockRemoveListener,
+  send: jest.fn(),
+  removeAllListeners: jest.fn(),
+};
+
+// Setup window.electronAPI mock
+beforeAll(() => {
+  Object.defineProperty(window, 'electronAPI', {
+    value: mockElectronAPI,
+    writable: true,
+    configurable: true,
+  });
+});
+
+// Import hook after setting up mock
+import { useServiceStatus } from '../../../src/renderer/hooks/useServiceStatus';
+
+describe('T010.2 - useServiceStatus Hook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+
+    // Default mock responses
+    mockInvoke.mockImplementation((channel: string) => {
+      if (channel === 'ai:get-status') {
+        return Promise.resolve({ status: 'stopped', running: false });
+      }
+      if (channel === 'bridge:check-health') {
+        return Promise.resolve({ status: 'stopped', healthy: false });
+      }
+      return Promise.resolve(null);
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // ==========================================================================
+  // T010.2.1 - Hook Structure Tests
+  // ==========================================================================
+
+  describe('T010.2.1 - Hook Structure', () => {
+    it('should export useServiceStatus hook', () => {
+      expect(useServiceStatus).toBeDefined();
+      expect(typeof useServiceStatus).toBe('function');
+    });
+
+    it('should return aiStatus', async () => {
+      const { result } = renderHook(() => useServiceStatus());
+
+      await waitFor(() => {
+        expect(result.current.aiStatus).toBeDefined();
+      });
+    });
+
+    it('should return bridgeStatus', async () => {
+      const { result } = renderHook(() => useServiceStatus());
+
+      await waitFor(() => {
+        expect(result.current.bridgeStatus).toBeDefined();
+      });
+    });
+
+    it('should return companyName', async () => {
+      const { result } = renderHook(() => useServiceStatus());
+
+      await waitFor(() => {
+        expect(result.current).toHaveProperty('companyName');
+      });
+    });
+
+    it('should return isLoading flag', async () => {
+      const { result } = renderHook(() => useServiceStatus());
+
+      expect(typeof result.current.isLoading).toBe('boolean');
+    });
+
+    it('should return refresh function', async () => {
+      const { result } = renderHook(() => useServiceStatus());
+
+      expect(typeof result.current.refresh).toBe('function');
+    });
+  });
+
+  // ==========================================================================
+  // T010.2.2 - Polling Tests
+  // ==========================================================================
+
+  describe('T010.2.2 - Status Polling', () => {
+    it('should fetch status on mount', async () => {
+      renderHook(() => useServiceStatus());
+
+      await waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalledWith('ai:get-status');
+        expect(mockInvoke).toHaveBeenCalledWith('bridge:check-health');
+      });
+    });
+
+    it('should poll every 5 seconds', async () => {
+      jest.useFakeTimers();
+
+      renderHook(() => useServiceStatus());
+
+      // Initial fetch
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockInvoke).toHaveBeenCalledTimes(2); // ai + bridge
+
+      // Fast forward 5 seconds
+      await act(async () => {
+        jest.advanceTimersByTime(5000);
+        await Promise.resolve();
+      });
+
+      expect(mockInvoke).toHaveBeenCalledTimes(4); // 2 more calls
+    });
+
+    it('should stop polling on unmount', async () => {
+      jest.useFakeTimers();
+
+      const { unmount } = renderHook(() => useServiceStatus());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockInvoke).toHaveBeenCalled();
+
+      const callCountBeforeUnmount = mockInvoke.mock.calls.length;
+      unmount();
+
+      await act(async () => {
+        jest.advanceTimersByTime(10000);
+        await Promise.resolve();
+      });
+
+      // Should not have made any more calls after unmount
+      expect(mockInvoke).toHaveBeenCalledTimes(callCountBeforeUnmount);
+    });
+
+    it('should update aiStatus from poll response', async () => {
+      mockInvoke.mockImplementation((channel: string) => {
+        if (channel === 'ai:get-status') {
+          return Promise.resolve({ status: 'running', running: true });
+        }
+        if (channel === 'bridge:check-health') {
+          return Promise.resolve({ status: 'stopped', healthy: false });
+        }
+        return Promise.resolve(null);
+      });
+
+      const { result } = renderHook(() => useServiceStatus());
+
+      await waitFor(() => {
+        expect(result.current.aiStatus).toBe('running');
+      });
+    });
+
+    it('should update bridgeStatus from poll response', async () => {
+      mockInvoke.mockImplementation((channel: string) => {
+        if (channel === 'ai:get-status') {
+          return Promise.resolve({ status: 'stopped', running: false });
+        }
+        if (channel === 'bridge:check-health') {
+          return Promise.resolve({ status: 'running', healthy: true });
+        }
+        return Promise.resolve(null);
+      });
+
+      const { result } = renderHook(() => useServiceStatus());
+
+      await waitFor(() => {
+        expect(result.current.bridgeStatus).toBe('running');
+      });
+    });
+
+    it('should handle poll errors gracefully', async () => {
+      mockInvoke.mockRejectedValue(new Error('Network error'));
+
+      const { result } = renderHook(() => useServiceStatus());
+
+      // Should set error status
+      await waitFor(() => {
+        expect(result.current.aiStatus).toBe('error');
+      });
+    });
+  });
+
+  // ==========================================================================
+  // T010.2.3 - Event-based Updates
+  // ==========================================================================
+
+  describe('T010.2.3 - Event Updates', () => {
+    it('should subscribe to ai:status-changed on mount', async () => {
+      renderHook(() => useServiceStatus());
+
+      await waitFor(() => {
+        expect(mockOn).toHaveBeenCalledWith('ai:status-changed', expect.any(Function));
+      });
+    });
+
+    it('should subscribe to bridge:status-changed on mount', async () => {
+      renderHook(() => useServiceStatus());
+
+      await waitFor(() => {
+        expect(mockOn).toHaveBeenCalledWith('bridge:status-changed', expect.any(Function));
+      });
+    });
+
+    it('should unsubscribe from events on unmount', async () => {
+      const { unmount } = renderHook(() => useServiceStatus());
+
+      await waitFor(() => {
+        expect(mockOn).toHaveBeenCalled();
+      });
+
+      unmount();
+
+      expect(mockRemoveListener).toHaveBeenCalledWith('ai:status-changed', expect.any(Function));
+      expect(mockRemoveListener).toHaveBeenCalledWith('bridge:status-changed', expect.any(Function));
+    });
+
+    it('should update aiStatus when ai:status-changed event fires', async () => {
+      let aiStatusCallback: ((data: any) => void) | null = null;
+
+      mockOn.mockImplementation((channel: string, callback: (data: any) => void) => {
+        if (channel === 'ai:status-changed') {
+          aiStatusCallback = callback;
+        }
+      });
+
+      const { result } = renderHook(() => useServiceStatus());
+
+      // Wait for initial state
+      await waitFor(() => {
+        expect(result.current.aiStatus).toBeDefined();
+      });
+
+      // Simulate status change event
+      await act(async () => {
+        if (aiStatusCallback) {
+          aiStatusCallback({ status: 'running' });
+        }
+      });
+
+      expect(result.current.aiStatus).toBe('running');
+    });
+
+    it('should update bridgeStatus when bridge:status-changed event fires', async () => {
+      let bridgeStatusCallback: ((data: any) => void) | null = null;
+
+      mockOn.mockImplementation((channel: string, callback: (data: any) => void) => {
+        if (channel === 'bridge:status-changed') {
+          bridgeStatusCallback = callback;
+        }
+      });
+
+      const { result } = renderHook(() => useServiceStatus());
+
+      await waitFor(() => {
+        expect(result.current.bridgeStatus).toBeDefined();
+      });
+
+      await act(async () => {
+        if (bridgeStatusCallback) {
+          bridgeStatusCallback({ status: 'error' });
+        }
+      });
+
+      expect(result.current.bridgeStatus).toBe('error');
+    });
+  });
+
+  // ==========================================================================
+  // T010.2.4 - Startup State
+  // ==========================================================================
+
+  describe('T010.2.4 - Startup State', () => {
+    it('should show "starting" as initial state', () => {
+      // Make the first poll slow
+      mockInvoke.mockImplementation(() => new Promise(() => {})); // Never resolves
+
+      const { result } = renderHook(() => useServiceStatus());
+
+      // Initial state should be starting
+      expect(result.current.aiStatus).toBe('starting');
+      expect(result.current.bridgeStatus).toBe('starting');
+    });
+
+    it('should show isLoading true during initial fetch', () => {
+      mockInvoke.mockImplementation(() => new Promise(() => {}));
+
+      const { result } = renderHook(() => useServiceStatus());
+
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it('should show isLoading false after fetch completes', async () => {
+      const { result } = renderHook(() => useServiceStatus());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+    });
+
+    it('should transition from starting to actual status', async () => {
+      let resolveAi: (value: any) => void;
+      const aiPromise = new Promise((resolve) => {
+        resolveAi = resolve;
+      });
+
+      mockInvoke.mockImplementation((channel: string) => {
+        if (channel === 'ai:get-status') {
+          return aiPromise;
+        }
+        return Promise.resolve({ status: 'stopped' });
+      });
+
+      const { result } = renderHook(() => useServiceStatus());
+
+      // Initially starting
+      expect(result.current.aiStatus).toBe('starting');
+
+      // Resolve the promise
+      await act(async () => {
+        resolveAi!({ status: 'running', running: true });
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(result.current.aiStatus).toBe('running');
+      });
+    });
+  });
+
+  // ==========================================================================
+  // Refresh Function Tests
+  // ==========================================================================
+
+  describe('Refresh Function', () => {
+    it('should allow manual refresh', async () => {
+      const { result } = renderHook(() => useServiceStatus());
+
+      await waitFor(() => {
+        expect(mockInvoke).toHaveBeenCalled();
+      });
+
+      const callCountBefore = mockInvoke.mock.calls.length;
+
+      await act(async () => {
+        result.current.refresh();
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(mockInvoke.mock.calls.length).toBeGreaterThan(callCountBefore);
+      });
+    });
+  });
+});

--- a/log_files/T010.2_useServiceStatus_Log.md
+++ b/log_files/T010.2_useServiceStatus_Log.md
@@ -1,0 +1,82 @@
+# T010.2 Implementation Log: useServiceStatus Hook
+
+## Date: 2025-12-17
+
+## Task Overview
+Create useServiceStatus hook for managing AI and Bridge service status with polling and event-based updates.
+
+## Implementation Details
+
+### Files Created
+- `desktop-app/src/renderer/hooks/useServiceStatus.ts` - Custom React hook
+- `desktop-app/tests/renderer/hooks/useServiceStatus.test.ts` - 22 tests
+
+### Key Components
+
+#### useServiceStatus Hook
+```typescript
+export function useServiceStatus(): UseServiceStatusResult {
+  const [aiStatus, setAiStatus] = useState<ServiceStatus>('starting');
+  const [bridgeStatus, setBridgeStatus] = useState<ServiceStatus>('starting');
+  const [companyName, setCompanyName] = useState<string | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState(true);
+
+  return { aiStatus, bridgeStatus, companyName, isLoading, refresh };
+}
+```
+
+#### Return Type
+```typescript
+export interface UseServiceStatusResult {
+  aiStatus: ServiceStatus;
+  bridgeStatus: ServiceStatus;
+  companyName: string | undefined;
+  isLoading: boolean;
+  refresh: () => void;
+}
+```
+
+### Features Implemented
+
+#### T010.2.1 - Hook Structure
+- Export `useServiceStatus` hook
+- Return `aiStatus`, `bridgeStatus`, `companyName`, `isLoading`, `refresh`
+- Initial state: `starting` for both services
+
+#### T010.2.2 - Status Polling
+- Polls every 5 seconds using `setInterval`
+- Fetches AI status via `window.electronAPI.invoke('ai:get-status')`
+- Fetches Bridge status via `window.electronAPI.invoke('bridge:check-health')`
+- Cleanup: clears interval on unmount
+
+#### T010.2.3 - Event-based Updates
+- Subscribes to `ai:status-changed` event
+- Subscribes to `bridge:status-changed` event
+- Cleanup: removes listeners on unmount
+
+#### T010.2.4 - Startup State
+- Initial state shows `starting` during first fetch
+- `isLoading` starts as `true`
+- Transitions to actual status after first poll completes
+
+### IPC Channels Used
+| Channel | Type | Purpose |
+|---------|------|---------|
+| ai:get-status | invoke | Get current AI service status |
+| bridge:check-health | invoke | Get current Bridge health/status |
+| ai:status-changed | on | Listen for AI status changes |
+| bridge:status-changed | on | Listen for Bridge status changes |
+
+### Error Handling
+- Network errors set status to `error`
+- Uses `isMountedRef` to prevent state updates after unmount
+- Console logs errors for debugging
+
+## Test Results
+- 22 tests written, all passing
+- Tests cover: hook structure, polling, event updates, startup state, refresh function
+
+## Notes
+- Hook uses React 18 patterns with useCallback and useRef
+- All T010.2 subtasks implemented together as cohesive functionality
+- Polling interval: 5000ms (5 seconds)

--- a/log_learn/T010.2_useServiceStatus_LearnLog.md
+++ b/log_learn/T010.2_useServiceStatus_LearnLog.md
@@ -1,0 +1,86 @@
+# T010.2 Learning Log: useServiceStatus Hook
+
+## Date: 2025-12-17
+
+## Key Learnings
+
+### 1. React Testing Library with Fake Timers
+**Challenge**: Testing hooks that use `setInterval` with React 18's concurrent mode caused "Should not already be working" errors.
+
+**Solution**:
+- Use `jest.useFakeTimers()` only in specific tests that need timing control
+- Call `jest.useRealTimers()` in `beforeEach` and `afterEach`
+- Wrap timer advances in `act()`:
+```typescript
+await act(async () => {
+  jest.advanceTimersByTime(5000);
+  await Promise.resolve();
+});
+```
+
+### 2. Window Mock Setup Order
+**Challenge**: Module imports execute before `beforeAll` hooks, so mocks must be set up at module scope.
+
+**Solution**:
+- Define mock at module level before imports
+- Use `Object.defineProperty` with `configurable: true` for flexibility:
+```typescript
+beforeAll(() => {
+  Object.defineProperty(window, 'electronAPI', {
+    value: mockElectronAPI,
+    writable: true,
+    configurable: true,
+  });
+});
+```
+
+### 3. Preventing Memory Leaks in Hooks
+**Pattern**: Use `isMountedRef` to track component lifecycle:
+```typescript
+const isMountedRef = useRef(true);
+
+useEffect(() => {
+  isMountedRef.current = true;
+  return () => {
+    isMountedRef.current = false;
+  };
+}, []);
+```
+
+This prevents state updates after unmount.
+
+### 4. Testing Event Subscriptions
+**Pattern**: Capture callbacks from mock to simulate events:
+```typescript
+let callback: ((data: any) => void) | null = null;
+
+mockOn.mockImplementation((channel, cb) => {
+  if (channel === 'ai:status-changed') {
+    callback = cb;
+  }
+});
+
+// Later, simulate event:
+await act(async () => {
+  if (callback) callback({ status: 'running' });
+});
+```
+
+### 5. useCallback Dependencies
+**Learning**: `useCallback` with empty dependencies `[]` creates a stable reference but won't update if external values change. For `fetchStatus`, no external dependencies were needed since it uses refs and state setters (which are stable).
+
+## Best Practices Discovered
+
+1. **Separate concerns**: Hook handles data fetching, component handles display
+2. **Use refs for mutable values**: `pollIntervalRef` and `isMountedRef` prevent stale closure issues
+3. **Clean up properly**: Always return cleanup function from `useEffect`
+4. **Test initial state synchronously**: For tests checking initial values, don't use async patterns
+
+## Files Referenced
+- `desktop-app/src/renderer/hooks/useServiceStatus.ts`
+- `desktop-app/tests/renderer/hooks/useServiceStatus.test.ts`
+
+## Related Documentation
+- [React Testing Library - renderHook](https://testing-library.com/docs/react-testing-library/api/#renderhook)
+- [Jest - Timer Mocks](https://jestjs.io/docs/timer-mocks)
+- [React 18 - act() warnings](https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis)

--- a/log_tests/T010.2_useServiceStatus_TestLog.md
+++ b/log_tests/T010.2_useServiceStatus_TestLog.md
@@ -1,0 +1,88 @@
+# T010.2 Test Log: useServiceStatus Hook
+
+## Date: 2025-12-17
+
+## Test File
+`desktop-app/tests/renderer/hooks/useServiceStatus.test.ts`
+
+## Test Summary
+- **Total Tests**: 22
+- **Passed**: 22
+- **Failed**: 0
+
+## Test Categories
+
+### T010.2.1 - Hook Structure (6 tests)
+| Test | Status |
+|------|--------|
+| should export useServiceStatus hook | PASS |
+| should return aiStatus | PASS |
+| should return bridgeStatus | PASS |
+| should return companyName | PASS |
+| should return isLoading flag | PASS |
+| should return refresh function | PASS |
+
+### T010.2.2 - Status Polling (6 tests)
+| Test | Status |
+|------|--------|
+| should fetch status on mount | PASS |
+| should poll every 5 seconds | PASS |
+| should stop polling on unmount | PASS |
+| should update aiStatus from poll response | PASS |
+| should update bridgeStatus from poll response | PASS |
+| should handle poll errors gracefully | PASS |
+
+### T010.2.3 - Event Updates (5 tests)
+| Test | Status |
+|------|--------|
+| should subscribe to ai:status-changed on mount | PASS |
+| should subscribe to bridge:status-changed on mount | PASS |
+| should unsubscribe from events on unmount | PASS |
+| should update aiStatus when ai:status-changed event fires | PASS |
+| should update bridgeStatus when bridge:status-changed event fires | PASS |
+
+### T010.2.4 - Startup State (4 tests)
+| Test | Status |
+|------|--------|
+| should show "starting" as initial state | PASS |
+| should show isLoading true during initial fetch | PASS |
+| should show isLoading false after fetch completes | PASS |
+| should transition from starting to actual status | PASS |
+
+### Refresh Function (1 test)
+| Test | Status |
+|------|--------|
+| should allow manual refresh | PASS |
+
+## Test Commands
+```bash
+# Run useServiceStatus tests only
+npm test -- --testPathPattern="useServiceStatus"
+
+# Run all tests
+npm test
+```
+
+## Mock Setup
+```typescript
+const mockElectronAPI = {
+  invoke: mockInvoke,
+  on: mockOn,
+  removeListener: mockRemoveListener,
+  send: jest.fn(),
+  removeAllListeners: jest.fn(),
+};
+
+beforeAll(() => {
+  Object.defineProperty(window, 'electronAPI', {
+    value: mockElectronAPI,
+    writable: true,
+    configurable: true,
+  });
+});
+```
+
+## Total Project Tests
+- Previous: 416 tests
+- Added: 22 tests (useServiceStatus)
+- Total: 438 tests

--- a/specs/001-windows-native-ai/tasks.md
+++ b/specs/001-windows-native-ai/tasks.md
@@ -813,13 +813,20 @@
   - [x] T010.1.5 Display current company name if connected ✅ *Completed 2025-12-17*
     - Conditionally rendered when companyName prop is provided
 
-- [ ] **T010.2** Implement status polling hook
-  - [ ] T010.2.1 Create `useServiceStatus.ts` hook
-  - [ ] T010.2.2 Poll both services every 5 seconds
-  - [ ] T010.2.3 Update status on service events
-  - [ ] T010.2.4 Show "Iniciando..." during startup
+- [x] **T010.2** Implement status polling hook ✅ *Completed 2025-12-17*
+  - [x] T010.2.1 Create `useServiceStatus.ts` hook ✅ *Completed 2025-12-17*
+    - Returns aiStatus, bridgeStatus, companyName, isLoading, refresh
+    - Initial state: 'starting' for both services
+  - [x] T010.2.2 Poll both services every 5 seconds ✅ *Completed 2025-12-17*
+    - Uses setInterval with 5000ms interval
+    - Fetches via electronAPI.invoke
+  - [x] T010.2.3 Update status on service events ✅ *Completed 2025-12-17*
+    - Subscribes to ai:status-changed and bridge:status-changed
+    - Proper cleanup on unmount
+  - [x] T010.2.4 Show "Iniciando..." during startup ✅ *Completed 2025-12-17*
+    - isLoading starts true, becomes false after first fetch
 
-**Checkpoint**: Status bar shows service health
+**Checkpoint**: Status bar shows service health ✅ *T010 Complete*
 
 ---
 


### PR DESCRIPTION
Add custom React hook for managing AI and Bridge service status:
- Poll both services every 5 seconds via IPC invoke
- Subscribe to status-changed events for real-time updates
- Initial state shows 'starting' during first fetch
- Provides refresh function for manual status refresh
- Proper cleanup on unmount (intervals and listeners)

Tests: 22 new tests (438 total)