### PR TITLE
feat(T014.2): implement batch extraction endpoint for multiple PDFs

### DIFF
--- a/ai-service/src/api/routes.py
+++ b/ai-service/src/api/routes.py
@@ -19,7 +19,14 @@ from ..services.extraction_service import (
     FileTooLargeError,
     MAX_FILE_SIZE,
 )
-from ..models.extraction import InvoiceExtraction
+from ..models.extraction import (
+    InvoiceExtraction,
+    BatchResultItem,
+    BatchExtractionResponse,
+)
+
+# Maximum number of files in a batch
+MAX_BATCH_FILES = 20
 
 logger = logging.getLogger(__name__)
 
@@ -363,3 +370,111 @@ async def extract_invoice(
             status_code=500,
             detail="Error interno del servidor durante la extracción",
         )
+
+
+@router.post("/extract/batch", response_model=BatchExtractionResponse)
+async def extract_batch(
+    files: List[UploadFile] = File(..., description="PDF files to extract invoice data from")
+) -> BatchExtractionResponse:
+    """
+    Extract invoice data from multiple uploaded PDF files.
+
+    This endpoint accepts multiple PDF files and processes them sequentially,
+    returning a BatchExtractionResponse with per-file results.
+
+    Files are processed one at a time to avoid memory issues. If one file
+    fails, processing continues with the remaining files.
+
+    Args:
+        files: List of PDF file uploads (multipart/form-data)
+
+    Returns:
+        BatchExtractionResponse: Results for all files with success/failure counts
+
+    Raises:
+        HTTPException 400: If any file is not a valid PDF
+        HTTPException 422: If too many files are provided
+    """
+    import time
+    start_time = time.time()
+
+    # Validate batch size
+    if len(files) > MAX_BATCH_FILES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Demasiados archivos. El máximo es {MAX_BATCH_FILES} archivos por lote.",
+        )
+
+    # Validate all files are PDFs before processing
+    for file in files:
+        content_type = file.content_type or ""
+        filename = file.filename or ""
+        if not content_type.startswith("application/pdf") and not filename.lower().endswith(".pdf"):
+            raise HTTPException(
+                status_code=400,
+                detail=f"El archivo '{filename}' no es un PDF. Todos los archivos deben ser PDF.",
+            )
+
+    # Create extraction service
+    service = ExtractionService()
+
+    results: List[BatchResultItem] = []
+    successful = 0
+    failed = 0
+
+    # Process files sequentially
+    for file in files:
+        filename = file.filename or "document.pdf"
+
+        try:
+            # Read file content
+            content = await file.read()
+
+            # Check file size
+            if len(content) > MAX_FILE_SIZE:
+                results.append(BatchResultItem(
+                    filename=filename,
+                    success=False,
+                    error=f"El archivo excede el tamaño máximo de {MAX_FILE_SIZE // (1024 * 1024)}MB",
+                ))
+                failed += 1
+                continue
+
+            # Extract invoice data
+            extraction = service.extract(content, filename=filename)
+
+            results.append(BatchResultItem(
+                filename=filename,
+                success=True,
+                extraction=extraction,
+            ))
+            successful += 1
+
+        except InvalidPDFError as e:
+            logger.warning(f"Invalid PDF in batch '{filename}': {e}")
+            results.append(BatchResultItem(
+                filename=filename,
+                success=False,
+                error=str(e),
+            ))
+            failed += 1
+
+        except Exception as e:
+            logger.error(f"Extraction failed for '{filename}': {e}")
+            results.append(BatchResultItem(
+                filename=filename,
+                success=False,
+                error=f"Error en la extracción: {str(e)}",
+            ))
+            failed += 1
+
+    # Calculate total processing time
+    total_processing_time_ms = int((time.time() - start_time) * 1000)
+
+    return BatchExtractionResponse(
+        results=results,
+        total_files=len(files),
+        successful=successful,
+        failed=failed,
+        total_processing_time_ms=total_processing_time_ms,
+    )

--- a/ai-service/src/models/__init__.py
+++ b/ai-service/src/models/__init__.py
@@ -20,6 +20,8 @@ from .extraction import (
     ExtractionField,
     LineItemExtraction,
     InvoiceExtraction,
+    BatchResultItem,
+    BatchExtractionResponse,
 )
 
 __all__ = [
@@ -27,4 +29,6 @@ __all__ = [
     "ExtractionField",
     "LineItemExtraction",
     "InvoiceExtraction",
+    "BatchResultItem",
+    "BatchExtractionResponse",
 ]

--- a/ai-service/src/models/extraction.py
+++ b/ai-service/src/models/extraction.py
@@ -290,9 +290,63 @@ class InvoiceExtraction(BaseModel):
         ])
 
 
+class BatchResultItem(BaseModel):
+    """
+    Result for a single file in a batch extraction.
+
+    Contains either the extraction result on success,
+    or an error message on failure.
+
+    Attributes:
+        filename: Original filename
+        success: Whether extraction succeeded
+        extraction: Extraction result (if successful)
+        error: Error message (if failed)
+    """
+    filename: str = Field(..., description="Original filename")
+    success: bool = Field(..., description="Whether extraction succeeded")
+    extraction: Optional[InvoiceExtraction] = Field(
+        default=None,
+        description="Extraction result (if successful)"
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Error message (if failed)"
+    )
+
+
+class BatchExtractionResponse(BaseModel):
+    """
+    Response for batch extraction endpoint.
+
+    Contains results for all files in the batch,
+    along with summary statistics.
+
+    Attributes:
+        results: List of per-file results
+        total_files: Total number of files in batch
+        successful: Number of successful extractions
+        failed: Number of failed extractions
+        total_processing_time_ms: Total processing time in milliseconds
+    """
+    results: List[BatchResultItem] = Field(
+        ...,
+        description="Per-file extraction results"
+    )
+    total_files: int = Field(..., description="Total files in batch")
+    successful: int = Field(..., description="Successful extractions")
+    failed: int = Field(..., description="Failed extractions")
+    total_processing_time_ms: int = Field(
+        ...,
+        description="Total processing time in milliseconds"
+    )
+
+
 __all__ = [
     "BoundingBox",
     "ExtractionField",
     "LineItemExtraction",
     "InvoiceExtraction",
+    "BatchResultItem",
+    "BatchExtractionResponse",
 ]

--- a/ai-service/tests/integration/test_batch_extract_endpoint.py
+++ b/ai-service/tests/integration/test_batch_extract_endpoint.py
@@ -1,0 +1,389 @@
+"""
+T014.2 - Tests for POST /extract/batch endpoint
+
+Tests for the batch invoice extraction API endpoint that:
+- Accepts multiple PDF files
+- Processes files sequentially to avoid memory issues
+- Returns BatchExtractionResponse with per-file results
+"""
+
+import io
+from decimal import Decimal
+from typing import List
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.routes import router
+from src.models.extraction import (
+    ExtractionField,
+    InvoiceExtraction,
+    LineItemExtraction,
+)
+
+
+@pytest.fixture
+def app():
+    """Create FastAPI app with routes."""
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def client(app):
+    """Create test client."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def sample_pdf_bytes():
+    """Create a minimal valid PDF for testing."""
+    pdf_content = b"""%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 44 >>
+stream
+BT
+/F1 12 Tf
+100 700 Td
+(Test Invoice) Tj
+ET
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f
+0000000009 00000 n
+0000000058 00000 n
+0000000115 00000 n
+0000000206 00000 n
+trailer
+<< /Size 5 /Root 1 0 R >>
+startxref
+300
+%%EOF"""
+    return pdf_content
+
+
+@pytest.fixture
+def mock_extraction_result():
+    """Mock InvoiceExtraction result."""
+    return InvoiceExtraction(
+        source_file="test.pdf",
+        source_type="text",
+        vendor_rfc=ExtractionField(
+            field_name="vendor_rfc",
+            value="ABC123456789",
+            confidence=0.95,
+        ),
+        total=ExtractionField(
+            field_name="total",
+            value="1000.00",
+            confidence=0.90,
+        ),
+        overall_confidence=0.90,
+        processing_time_ms=100,
+    )
+
+
+class TestBatchEndpointExists:
+    """Tests that the batch endpoint exists and responds."""
+
+    def test_batch_endpoint_exists(self, client, sample_pdf_bytes):
+        """POST /extract/batch endpoint should exist."""
+        files = [
+            ("files", ("test1.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf")),
+        ]
+
+        with patch("src.api.routes.ExtractionService") as mock_service:
+            mock_service.return_value.extract.return_value = InvoiceExtraction(
+                source_file="test1.pdf",
+                source_type="text",
+                processing_time_ms=100,
+            )
+            response = client.post("/extract/batch", files=files)
+
+        # Should not return 404
+        assert response.status_code != 404
+
+    def test_batch_requires_files(self, client):
+        """Should return 422 if no files provided."""
+        response = client.post("/extract/batch")
+
+        assert response.status_code == 422
+
+
+class TestBatchFileValidation:
+    """Tests for batch file validation."""
+
+    def test_accepts_multiple_pdf_files(self, client, sample_pdf_bytes, mock_extraction_result):
+        """Should accept multiple PDF files."""
+        files = [
+            ("files", ("invoice1.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf")),
+            ("files", ("invoice2.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf")),
+            ("files", ("invoice3.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf")),
+        ]
+
+        with patch("src.api.routes.ExtractionService") as mock_service:
+            mock_service.return_value.extract.return_value = mock_extraction_result
+            response = client.post("/extract/batch", files=files)
+
+        assert response.status_code == 200
+
+    def test_rejects_non_pdf_in_batch(self, client, sample_pdf_bytes):
+        """Should reject batch containing non-PDF file."""
+        files = [
+            ("files", ("invoice1.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf")),
+            ("files", ("document.txt", io.BytesIO(b"Hello"), "text/plain")),
+        ]
+
+        response = client.post("/extract/batch", files=files)
+
+        # Should reject with error
+        assert response.status_code == 400
+
+
+class TestBatchExtractionResponse:
+    """Tests for BatchExtractionResponse format."""
+
+    def test_returns_batch_response(self, client, sample_pdf_bytes, mock_extraction_result):
+        """Should return BatchExtractionResponse structure."""
+        files = [
+            ("files", ("test1.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf")),
+            ("files", ("test2.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf")),
+        ]
+
+        with patch("src.api.routes.ExtractionService") as mock_service:
+            mock_service.return_value.extract.return_value = mock_extraction_result
+            response = client.post("/extract/batch", files=files)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should have batch response fields
+        assert "results" in data
+        assert "total_files" in data
+        assert "successful" in data
+        assert "failed" in data
+
+    def test_results_array_matches_file_count(self, client, sample_pdf_bytes, mock_extraction_result):
+        """Results array should have one entry per file."""
+        files = [
+            ("files", ("test1.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf")),
+            ("files", ("test2.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf")),
+            ("files", ("test3.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf")),
+        ]
+
+        with patch("src.api.routes.ExtractionService") as mock_service:
+            mock_service.return_value.extract.return_value = mock_extraction_result
+            response = client.post("/extract/batch", files=files)
+
+        data = response.json()
+        assert len(data["results"]) == 3
+        assert data["total_files"] == 3
+
+    def test_each_result_has_filename(self, client, sample_pdf_bytes, mock_extraction_result):
+        """Each result should include the original filename."""
+        files = [
+            ("files", ("invoice_001.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf")),
+            ("files", ("invoice_002.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf")),
+        ]
+
+        with patch("src.api.routes.ExtractionService") as mock_service:
+            # Return result with matching filename
+            def mock_extract(content, filename):
+                return InvoiceExtraction(
+                    source_file=filename,
+                    source_type="text",
+                    processing_time_ms=100,
+                )
+            mock_service.return_value.extract.side_effect = mock_extract
+            response = client.post("/extract/batch", files=files)
+
+        data = response.json()
+        filenames = [r["extraction"]["source_file"] for r in data["results"] if r.get("extraction")]
+        assert "invoice_001.pdf" in filenames
+        assert "invoice_002.pdf" in filenames
+
+    def test_includes_total_processing_time(self, client, sample_pdf_bytes, mock_extraction_result):
+        """Should include total processing time for entire batch."""
+        files = [
+            ("files", ("test1.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf")),
+        ]
+
+        with patch("src.api.routes.ExtractionService") as mock_service:
+            mock_service.return_value.extract.return_value = mock_extraction_result
+            response = client.post("/extract/batch", files=files)
+
+        data = response.json()
+        assert "total_processing_time_ms" in data
+        assert isinstance(data["total_processing_time_ms"], int)
+
+
+class TestBatchSequentialProcessing:
+    """Tests for sequential processing (T014.2.3)."""
+
+    def test_processes_files_sequentially(self, client, sample_pdf_bytes):
+        """Files should be processed one at a time, not in parallel."""
+        files = [
+            ("files", ("test1.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf")),
+            ("files", ("test2.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf")),
+        ]
+
+        call_order = []
+
+        with patch("src.api.routes.ExtractionService") as mock_service:
+            def mock_extract(content, filename):
+                call_order.append(filename)
+                return InvoiceExtraction(
+                    source_file=filename,
+                    source_type="text",
+                    processing_time_ms=100,
+                )
+            mock_service.return_value.extract.side_effect = mock_extract
+            response = client.post("/extract/batch", files=files)
+
+        # All files should have been processed
+        assert len(call_order) == 2
+
+
+class TestBatchErrorHandling:
+    """Tests for error handling in batch processing."""
+
+    def test_continues_on_single_file_failure(self, client, sample_pdf_bytes, mock_extraction_result):
+        """Should continue processing if one file fails."""
+        files = [
+            ("files", ("good1.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf")),
+            ("files", ("bad.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf")),
+            ("files", ("good2.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf")),
+        ]
+
+        call_count = [0]
+
+        with patch("src.api.routes.ExtractionService") as mock_service:
+            def mock_extract(content, filename):
+                call_count[0] += 1
+                if filename == "bad.pdf":
+                    raise Exception("Extraction failed")
+                return InvoiceExtraction(
+                    source_file=filename,
+                    source_type="text",
+                    processing_time_ms=100,
+                )
+            mock_service.return_value.extract.side_effect = mock_extract
+            response = client.post("/extract/batch", files=files)
+
+        data = response.json()
+        # Should have processed all 3 files
+        assert call_count[0] == 3
+        # Should report 2 successful, 1 failed
+        assert data["successful"] == 2
+        assert data["failed"] == 1
+
+    def test_failed_result_includes_error(self, client, sample_pdf_bytes, mock_extraction_result):
+        """Failed file result should include error message."""
+        files = [
+            ("files", ("bad.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf")),
+        ]
+
+        with patch("src.api.routes.ExtractionService") as mock_service:
+            mock_service.return_value.extract.side_effect = Exception("PDF corrupted")
+            response = client.post("/extract/batch", files=files)
+
+        data = response.json()
+        assert data["failed"] == 1
+
+        # Find the failed result
+        failed_result = data["results"][0]
+        assert failed_result["success"] is False
+        assert "error" in failed_result
+        assert "corrupted" in failed_result["error"].lower() or len(failed_result["error"]) > 0
+
+    def test_successful_result_has_extraction(self, client, sample_pdf_bytes, mock_extraction_result):
+        """Successful file result should include extraction data."""
+        files = [
+            ("files", ("good.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf")),
+        ]
+
+        with patch("src.api.routes.ExtractionService") as mock_service:
+            mock_service.return_value.extract.return_value = mock_extraction_result
+            response = client.post("/extract/batch", files=files)
+
+        data = response.json()
+        result = data["results"][0]
+
+        assert result["success"] is True
+        assert "extraction" in result
+        assert result["extraction"]["source_file"] == "test.pdf"
+
+
+class TestBatchLimits:
+    """Tests for batch size limits."""
+
+    def test_rejects_too_many_files(self, client, sample_pdf_bytes):
+        """Should reject batch with too many files."""
+        # Create more than max allowed files (e.g., 20)
+        files = [
+            ("files", (f"test{i}.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf"))
+            for i in range(25)
+        ]
+
+        response = client.post("/extract/batch", files=files)
+
+        # Should reject with appropriate error
+        assert response.status_code in [400, 413, 422]
+
+    def test_accepts_max_allowed_files(self, client, sample_pdf_bytes, mock_extraction_result):
+        """Should accept up to max allowed files."""
+        # Create exactly max allowed files (e.g., 20)
+        files = [
+            ("files", (f"test{i}.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf"))
+            for i in range(20)
+        ]
+
+        with patch("src.api.routes.ExtractionService") as mock_service:
+            mock_service.return_value.extract.return_value = mock_extraction_result
+            response = client.post("/extract/batch", files=files)
+
+        assert response.status_code == 200
+
+
+class TestBatchResponseFormat:
+    """Tests for complete batch response format."""
+
+    def test_complete_batch_response_schema(self, client, sample_pdf_bytes, mock_extraction_result):
+        """Response should match complete BatchExtractionResponse schema."""
+        files = [
+            ("files", ("test.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf")),
+        ]
+
+        with patch("src.api.routes.ExtractionService") as mock_service:
+            mock_service.return_value.extract.return_value = mock_extraction_result
+            response = client.post("/extract/batch", files=files)
+
+        data = response.json()
+
+        # Top-level fields
+        assert "results" in data
+        assert "total_files" in data
+        assert "successful" in data
+        assert "failed" in data
+        assert "total_processing_time_ms" in data
+
+        # Result entry fields
+        result = data["results"][0]
+        assert "filename" in result
+        assert "success" in result
+        # Either extraction or error
+        assert "extraction" in result or "error" in result

--- a/log_files/T014.2_BatchExtractEndpoint_Log.md
+++ b/log_files/T014.2_BatchExtractEndpoint_Log.md
@@ -1,0 +1,93 @@
+# T014.2 Implementation Log: Batch Extraction Endpoint
+
+## Date: 2025-12-18
+
+## Task Description
+Implement POST /extract/batch endpoint for batch invoice PDF extraction with sequential processing and per-file results.
+
+## Subtasks Completed
+
+### T014.2.1 - Write test_batch_extract_endpoint.py
+Created comprehensive integration test suite with 15 tests covering:
+- Endpoint existence and file requirements
+- Multiple PDF file validation
+- BatchExtractionResponse format
+- Sequential processing verification
+- Error handling (continue on failure)
+- Batch size limits (max 20 files)
+- Complete response schema
+
+### T014.2.2 - Create POST /extract/batch endpoint
+Added `POST /extract/batch` endpoint to `src/api/routes.py`:
+- Accepts `List[UploadFile]` for multiple files
+- Returns `BatchExtractionResponse` model
+- Validates all files are PDFs before processing
+
+### T014.2.3 - Process files sequentially
+Implemented sequential processing:
+- Files processed one at a time in for loop
+- Avoids memory issues from parallel processing
+- Each file read and processed independently
+- Processing continues if one file fails
+
+### T014.2.4 - Return BatchExtractionResponse
+Created response models in `extraction.py`:
+- `BatchResultItem`: Per-file result with success/failure
+- `BatchExtractionResponse`: Complete batch response with:
+  - `results`: List of per-file results
+  - `total_files`: Total files in batch
+  - `successful`: Successful extraction count
+  - `failed`: Failed extraction count
+  - `total_processing_time_ms`: Total processing time
+
+## Files Created/Modified
+- Created: `ai-service/tests/integration/test_batch_extract_endpoint.py`
+- Modified: `ai-service/src/api/routes.py`
+- Modified: `ai-service/src/models/extraction.py`
+- Modified: `ai-service/src/models/__init__.py`
+
+## Test Results
+- Total tests: 15
+- Passed: 15
+- Failed: 0
+
+## API Usage Example
+```bash
+curl -X POST "http://localhost:8000/extract/batch" \
+  -H "Content-Type: multipart/form-data" \
+  -F "files=@invoice1.pdf" \
+  -F "files=@invoice2.pdf" \
+  -F "files=@invoice3.pdf"
+```
+
+## Response Schema
+```json
+{
+  "results": [
+    {
+      "filename": "invoice1.pdf",
+      "success": true,
+      "extraction": { ... }
+    },
+    {
+      "filename": "invoice2.pdf",
+      "success": false,
+      "error": "Error message"
+    }
+  ],
+  "total_files": 2,
+  "successful": 1,
+  "failed": 1,
+  "total_processing_time_ms": 500
+}
+```
+
+## Configuration
+- MAX_BATCH_FILES = 20 (maximum files per batch)
+- MAX_FILE_SIZE = 50MB (per file limit)
+
+## Error Handling
+- Non-PDF files: Rejected with 400 before processing
+- Too many files: Rejected with 422
+- Individual file failures: Recorded in results, processing continues
+- Invalid PDF: Recorded as failed with Spanish error message

--- a/log_learn/T014.2_BatchExtractEndpoint_LearnLog.md
+++ b/log_learn/T014.2_BatchExtractEndpoint_LearnLog.md
@@ -1,0 +1,189 @@
+# T014.2 Learning Log: Batch Extraction Endpoint
+
+## Date: 2025-12-18
+
+## Key Learnings
+
+### 1. FastAPI Multiple File Uploads
+Handling multiple file uploads in FastAPI:
+
+```python
+from fastapi import File, UploadFile
+from typing import List
+
+@router.post("/extract/batch")
+async def extract_batch(
+    files: List[UploadFile] = File(..., description="PDF files to extract")
+) -> BatchExtractionResponse:
+    for file in files:
+        content = await file.read()
+        # Process file...
+```
+
+### 2. Sequential vs Parallel Processing
+Processing files sequentially to avoid memory issues:
+
+```python
+# Sequential (memory-efficient for large files)
+for file in files:
+    content = await file.read()
+    result = service.extract(content, filename=file.filename)
+    results.append(result)
+
+# vs Parallel (would consume more memory)
+# results = await asyncio.gather(*[process(f) for f in files])
+```
+
+### 3. Continue on Failure Pattern
+Processing continues even when individual files fail:
+
+```python
+results = []
+successful = 0
+failed = 0
+
+for file in files:
+    try:
+        extraction = service.extract(content, filename)
+        results.append(BatchResultItem(
+            filename=filename,
+            success=True,
+            extraction=extraction,
+        ))
+        successful += 1
+    except Exception as e:
+        results.append(BatchResultItem(
+            filename=filename,
+            success=False,
+            error=str(e),
+        ))
+        failed += 1
+```
+
+### 4. Batch Response Models
+Using Pydantic models for batch responses:
+
+```python
+class BatchResultItem(BaseModel):
+    filename: str
+    success: bool
+    extraction: Optional[InvoiceExtraction] = None
+    error: Optional[str] = None
+
+class BatchExtractionResponse(BaseModel):
+    results: List[BatchResultItem]
+    total_files: int
+    successful: int
+    failed: int
+    total_processing_time_ms: int
+```
+
+### 5. Pre-validation Before Processing
+Validating all files before processing any:
+
+```python
+# Validate all files are PDFs first
+for file in files:
+    content_type = file.content_type or ""
+    filename = file.filename or ""
+    if not is_pdf(content_type, filename):
+        raise HTTPException(
+            status_code=400,
+            detail=f"El archivo '{filename}' no es un PDF",
+        )
+
+# Then process files
+for file in files:
+    # ... extraction logic
+```
+
+### 6. Batch Size Limits
+Limiting batch size to prevent resource exhaustion:
+
+```python
+MAX_BATCH_FILES = 20
+
+if len(files) > MAX_BATCH_FILES:
+    raise HTTPException(
+        status_code=422,
+        detail=f"Máximo {MAX_BATCH_FILES} archivos por lote",
+    )
+```
+
+### 7. Testing Multiple File Uploads
+Using TestClient with multiple files:
+
+```python
+def test_multiple_files(client, sample_pdf_bytes):
+    files = [
+        ("files", ("test1.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf")),
+        ("files", ("test2.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf")),
+    ]
+
+    response = client.post("/extract/batch", files=files)
+
+    assert response.status_code == 200
+    assert len(response.json()["results"]) == 2
+```
+
+### 8. Tracking Processing Order
+Verifying sequential processing in tests:
+
+```python
+def test_sequential_processing(client, sample_pdf_bytes):
+    call_order = []
+
+    with patch("src.api.routes.ExtractionService") as mock_service:
+        def mock_extract(content, filename):
+            call_order.append(filename)
+            return InvoiceExtraction(...)
+        mock_service.return_value.extract.side_effect = mock_extract
+
+        response = client.post("/extract/batch", files=files)
+
+    # Verify all files were processed
+    assert len(call_order) == len(files)
+```
+
+### 9. Total Processing Time
+Tracking end-to-end batch processing time:
+
+```python
+import time
+
+start_time = time.time()
+
+# Process all files...
+
+total_processing_time_ms = int((time.time() - start_time) * 1000)
+
+return BatchExtractionResponse(
+    results=results,
+    total_processing_time_ms=total_processing_time_ms,
+)
+```
+
+### 10. Union Result Pattern
+Results can be either success with data or failure with error:
+
+```python
+# Each result has:
+# - Always: filename, success
+# - On success: extraction (InvoiceExtraction)
+# - On failure: error (str)
+
+class BatchResultItem(BaseModel):
+    filename: str = Field(...)
+    success: bool = Field(...)
+    extraction: Optional[InvoiceExtraction] = None
+    error: Optional[str] = None
+```
+
+## Files Referenced
+- `ai-service/src/api/routes.py`
+- `ai-service/src/models/extraction.py`
+- `ai-service/tests/integration/test_batch_extract_endpoint.py`
+
+## Related Documentation
+- [FastAPI Request Files](https://fastapi.tiangolo.com/tutorial/request-files/)
+- [Pydantic Optional Fields](https://docs.pydantic.dev/latest/concepts/types/)

--- a/log_tests/T014.2_BatchExtractEndpoint_TestLog.md
+++ b/log_tests/T014.2_BatchExtractEndpoint_TestLog.md
@@ -1,0 +1,92 @@
+# T014.2 Test Log: Batch Extraction Endpoint
+
+## Date: 2025-12-18
+
+## Test File
+`ai-service/tests/integration/test_batch_extract_endpoint.py`
+
+## Test Summary
+- **Total Tests**: 15
+- **Passed**: 15
+- **Skipped**: 0
+- **Failed**: 0
+
+## Test Categories
+
+### Endpoint Existence Tests (2 tests)
+| Test | Status |
+|------|--------|
+| test_batch_endpoint_exists | PASS |
+| test_batch_requires_files | PASS |
+
+### File Validation Tests (2 tests)
+| Test | Status |
+|------|--------|
+| test_accepts_multiple_pdf_files | PASS |
+| test_rejects_non_pdf_in_batch | PASS |
+
+### Batch Response Tests (4 tests)
+| Test | Status |
+|------|--------|
+| test_returns_batch_response | PASS |
+| test_results_array_matches_file_count | PASS |
+| test_each_result_has_filename | PASS |
+| test_includes_total_processing_time | PASS |
+
+### Sequential Processing Tests (1 test)
+| Test | Status |
+|------|--------|
+| test_processes_files_sequentially | PASS |
+
+### Error Handling Tests (3 tests)
+| Test | Status |
+|------|--------|
+| test_continues_on_single_file_failure | PASS |
+| test_failed_result_includes_error | PASS |
+| test_successful_result_has_extraction | PASS |
+
+### Batch Limits Tests (2 tests)
+| Test | Status |
+|------|--------|
+| test_rejects_too_many_files | PASS |
+| test_accepts_max_allowed_files | PASS |
+
+### Response Format Tests (1 test)
+| Test | Status |
+|------|--------|
+| test_complete_batch_response_schema | PASS |
+
+## Test Fixtures
+```python
+@pytest.fixture
+def sample_pdf_bytes():
+    """Create a minimal valid PDF for testing."""
+    # Returns valid PDF structure
+
+@pytest.fixture
+def mock_extraction_result():
+    """Mock InvoiceExtraction result."""
+    return InvoiceExtraction(
+        source_file="test.pdf",
+        source_type="text",
+        processing_time_ms=100,
+    )
+```
+
+## Test Commands
+```bash
+# Run batch endpoint tests only
+cd ai-service
+python -m pytest tests/integration/test_batch_extract_endpoint.py -v
+
+# Run all integration tests
+python -m pytest tests/integration/ -v
+```
+
+## Total AI Service Tests
+- T011: 32 tests (PDF extraction)
+- T012: 39 tests (OCR, preprocessing)
+- T013: 100 tests (AI extraction)
+- T014.1: 18 tests (Extract endpoint)
+- T014.2: 15 tests (Batch endpoint)
+- **Total: 204 tests (198 passed, 6 skipped)**

--- a/specs/001-windows-native-ai/tasks.md
+++ b/specs/001-windows-native-ai/tasks.md
@@ -948,11 +948,11 @@
   - [x] T014.1.6 Calculate and return processing_time_ms
   - [x] T014.1.7 Handle errors with Spanish messages
 
-- [ ] **T014.2** [P] Implement batch extraction endpoint
-  - [ ] T014.2.1 [P] Write test `test_batch_extract_endpoint.py`
-  - [ ] T014.2.2 Create POST /extract/batch endpoint
-  - [ ] T014.2.3 Process files sequentially (avoid memory issues)
-  - [ ] T014.2.4 Return BatchExtractionResponse with per-file results
+- [x] **T014.2** [P] Implement batch extraction endpoint ✅ 2025-12-18
+  - [x] T014.2.1 [P] Write test `test_batch_extract_endpoint.py`
+  - [x] T014.2.2 Create POST /extract/batch endpoint
+  - [x] T014.2.3 Process files sequentially (avoid memory issues)
+  - [x] T014.2.4 Return BatchExtractionResponse with per-file results
 
 **Checkpoint**: API extracts invoice data from uploaded PDF
 


### PR DESCRIPTION
Add POST /extract/batch endpoint for batch invoice processing:
- BatchResultItem and BatchExtractionResponse models
- Sequential file processing to avoid memory issues
- Continue-on-failure: individual file errors don't stop batch
- Pre-validation: all files checked as PDFs before processing
- Max 20 files per batch (MAX_BATCH_FILES)
- Spanish error messages for Mexican users

15 integration tests covering validation, processing, and error handling. Completes T014 checkpoint: API extracts invoice data from uploaded PDF.