### PR TITLE
feat(T016.2): implement BoundingBoxOverlay with confidence coloring

### DIFF
--- a/desktop-app/src/renderer/components/BoundingBoxOverlay.tsx
+++ b/desktop-app/src/renderer/components/BoundingBoxOverlay.tsx
@@ -1,0 +1,230 @@
+/**
+ * BoundingBoxOverlay Component
+ *
+ * Renders colored bounding boxes over a PDF to highlight extracted fields.
+ * Box colors indicate confidence levels:
+ * - Green (≥90%): High confidence
+ * - Orange (70-89%): Medium confidence
+ * - Red (<70%): Low confidence
+ *
+ * Uses Tailwind CSS for styling.
+ */
+
+import React, { useState, useCallback } from 'react';
+import type { ExtractionField } from '../types';
+
+/**
+ * Confidence thresholds for color coding
+ */
+const CONFIDENCE_HIGH = 90;
+const CONFIDENCE_MEDIUM = 70;
+
+/**
+ * Props for the BoundingBoxOverlay component
+ */
+export interface BoundingBoxOverlayProps {
+  /** Array of extraction fields with bounding boxes */
+  fields: ExtractionField[];
+  /** Current zoom scale (1 = 100%) */
+  scale: number;
+  /** Currently selected field name */
+  selectedField?: string;
+  /** Callback when a field box is clicked */
+  onFieldClick?: (fieldName: string) => void;
+  /** Callback when hovering over a field box */
+  onFieldHover?: (fieldName: string | null) => void;
+  /** Whether to show tooltips on hover */
+  showTooltip?: boolean;
+}
+
+/**
+ * Get Tailwind classes for border color based on confidence
+ */
+function getBorderColorClass(confidence: number): string {
+  if (confidence >= CONFIDENCE_HIGH) {
+    return 'border-green-500';
+  }
+  if (confidence >= CONFIDENCE_MEDIUM) {
+    return 'border-orange-500';
+  }
+  return 'border-red-500';
+}
+
+/**
+ * Get Tailwind classes for background color based on confidence
+ */
+function getBackgroundColorClass(confidence: number): string {
+  if (confidence >= CONFIDENCE_HIGH) {
+    return 'bg-green-500/20';
+  }
+  if (confidence >= CONFIDENCE_MEDIUM) {
+    return 'bg-orange-500/20';
+  }
+  return 'bg-red-500/20';
+}
+
+/**
+ * Props for individual bounding box
+ */
+interface BoxProps {
+  field: ExtractionField;
+  scale: number;
+  isSelected: boolean;
+  isHovered: boolean;
+  onClick: () => void;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+  showTooltip: boolean;
+}
+
+/**
+ * Individual bounding box component
+ */
+function Box({
+  field,
+  scale,
+  isSelected,
+  isHovered,
+  onClick,
+  onMouseEnter,
+  onMouseLeave,
+  showTooltip,
+}: BoxProps): JSX.Element | null {
+  if (!field.bbox) {
+    return null;
+  }
+
+  const { x, y, width, height } = field.bbox;
+
+  // Scale the position and dimensions
+  const scaledX = x * scale;
+  const scaledY = y * scale;
+  const scaledWidth = width * scale;
+  const scaledHeight = height * scale;
+
+  const borderColor = getBorderColorClass(field.confidence);
+  const backgroundColor = getBackgroundColorClass(field.confidence);
+
+  // Determine ring styling for selection/hover
+  const ringClasses = isSelected
+    ? 'ring-2 ring-blue-500'
+    : isHovered
+    ? 'ring-2 ring-gray-400'
+    : '';
+
+  return (
+    <div
+      data-testid={`bbox-${field.fieldName}`}
+      className={`
+        absolute
+        border-2
+        ${borderColor}
+        ${backgroundColor}
+        ${ringClasses}
+        cursor-pointer
+        transition-all
+        duration-150
+      `}
+      style={{
+        left: `${scaledX}px`,
+        top: `${scaledY}px`,
+        width: `${scaledWidth}px`,
+        height: `${scaledHeight}px`,
+      }}
+      onClick={onClick}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      {/* Tooltip */}
+      {showTooltip && isHovered && (
+        <div
+          data-testid="bbox-tooltip"
+          className="absolute bottom-full left-0 mb-1 px-2 py-1 bg-gray-800 text-white text-xs rounded whitespace-nowrap z-10"
+        >
+          {field.fieldName}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * BoundingBoxOverlay component for displaying extraction field highlights
+ *
+ * @example
+ * ```tsx
+ * <BoundingBoxOverlay
+ *   fields={extractionFields}
+ *   scale={1.5}
+ *   selectedField="vendor_rfc"
+ *   onFieldClick={(name) => setSelectedField(name)}
+ * />
+ * ```
+ */
+export function BoundingBoxOverlay({
+  fields,
+  scale,
+  selectedField,
+  onFieldClick,
+  onFieldHover,
+  showTooltip = false,
+}: BoundingBoxOverlayProps): JSX.Element {
+  const [hoveredField, setHoveredField] = useState<string | null>(null);
+
+  /**
+   * Handle box click
+   */
+  const handleClick = useCallback(
+    (fieldName: string) => {
+      onFieldClick?.(fieldName);
+    },
+    [onFieldClick]
+  );
+
+  /**
+   * Handle mouse enter
+   */
+  const handleMouseEnter = useCallback(
+    (fieldName: string) => {
+      setHoveredField(fieldName);
+      onFieldHover?.(fieldName);
+    },
+    [onFieldHover]
+  );
+
+  /**
+   * Handle mouse leave
+   */
+  const handleMouseLeave = useCallback(() => {
+    setHoveredField(null);
+    onFieldHover?.(null);
+  }, [onFieldHover]);
+
+  return (
+    <div
+      data-testid="bbox-overlay"
+      className="absolute inset-0 pointer-events-none"
+    >
+      {fields.map((field) => {
+        if (!field.bbox) return null;
+
+        return (
+          <div key={field.fieldName} className="pointer-events-auto">
+            <Box
+              field={field}
+              scale={scale}
+              isSelected={selectedField === field.fieldName}
+              isHovered={hoveredField === field.fieldName}
+              onClick={() => handleClick(field.fieldName)}
+              onMouseEnter={() => handleMouseEnter(field.fieldName)}
+              onMouseLeave={handleMouseLeave}
+              showTooltip={showTooltip}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default BoundingBoxOverlay;

--- a/desktop-app/tests/renderer/components/BoundingBoxOverlay.test.tsx
+++ b/desktop-app/tests/renderer/components/BoundingBoxOverlay.test.tsx
@@ -1,0 +1,551 @@
+/**
+ * T016.2 - BoundingBoxOverlay Component Tests
+ *
+ * Tests for the bounding box overlay component that:
+ * - Renders boxes at correct positions over PDF
+ * - Colors boxes by confidence level
+ * - Highlights active field on hover/selection
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { BoundingBox, ExtractionField } from '../../../src/renderer/types';
+
+// Will be created in T016.2.2
+let BoundingBoxOverlay: typeof import('../../../src/renderer/components/BoundingBoxOverlay').BoundingBoxOverlay;
+
+// Test data
+const createField = (
+  fieldName: string,
+  confidence: number,
+  bbox: BoundingBox
+): ExtractionField => ({
+  fieldName,
+  value: `Value for ${fieldName}`,
+  confidence,
+  bbox,
+  userVerified: false,
+});
+
+const mockFields: ExtractionField[] = [
+  createField('vendor_rfc', 95, { x: 100, y: 50, width: 200, height: 20 }),
+  createField('vendor_name', 85, { x: 100, y: 80, width: 250, height: 20 }),
+  createField('invoice_number', 60, { x: 400, y: 50, width: 100, height: 20 }),
+  createField('total', 92, { x: 400, y: 200, width: 80, height: 25 }),
+];
+
+describe('T016.2 - BoundingBoxOverlay Component', () => {
+  // ==========================================================================
+  // T016.2.1 - Component Structure Tests
+  // ==========================================================================
+
+  describe('T016.2.1 - Component Structure', () => {
+    it('should export BoundingBoxOverlay component', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      expect(module.BoundingBoxOverlay).toBeDefined();
+      expect(typeof module.BoundingBoxOverlay).toBe('function');
+    });
+
+    it('should render without crashing', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      expect(() => {
+        render(<BBO fields={mockFields} scale={1} />);
+      }).not.toThrow();
+    });
+
+    it('should render overlay container', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      render(<BBO fields={mockFields} scale={1} />);
+
+      expect(screen.getByTestId('bbox-overlay')).toBeInTheDocument();
+    });
+
+    it('should have absolute positioning', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      render(<BBO fields={mockFields} scale={1} />);
+
+      const overlay = screen.getByTestId('bbox-overlay');
+      expect(overlay).toHaveClass('absolute');
+    });
+  });
+
+  // ==========================================================================
+  // T016.2.2/3 - Box Rendering Tests
+  // ==========================================================================
+
+  describe('T016.2.2/3 - Box Rendering at Correct Positions', () => {
+    it('should render a box for each field with bbox', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      render(<BBO fields={mockFields} scale={1} />);
+
+      mockFields.forEach((field) => {
+        expect(screen.getByTestId(`bbox-${field.fieldName}`)).toBeInTheDocument();
+      });
+    });
+
+    it('should not render box for field without bbox', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      const fieldsWithMissing: ExtractionField[] = [
+        ...mockFields,
+        {
+          fieldName: 'no_bbox_field',
+          value: 'test',
+          confidence: 80,
+          userVerified: false,
+          // No bbox
+        },
+      ];
+
+      render(<BBO fields={fieldsWithMissing} scale={1} />);
+
+      expect(screen.queryByTestId('bbox-no_bbox_field')).not.toBeInTheDocument();
+    });
+
+    it('should position box at correct x coordinate', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      render(<BBO fields={mockFields} scale={1} />);
+
+      const box = screen.getByTestId('bbox-vendor_rfc');
+      expect(box).toHaveStyle({ left: '100px' });
+    });
+
+    it('should position box at correct y coordinate', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      render(<BBO fields={mockFields} scale={1} />);
+
+      const box = screen.getByTestId('bbox-vendor_rfc');
+      expect(box).toHaveStyle({ top: '50px' });
+    });
+
+    it('should set box width correctly', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      render(<BBO fields={mockFields} scale={1} />);
+
+      const box = screen.getByTestId('bbox-vendor_rfc');
+      expect(box).toHaveStyle({ width: '200px' });
+    });
+
+    it('should set box height correctly', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      render(<BBO fields={mockFields} scale={1} />);
+
+      const box = screen.getByTestId('bbox-vendor_rfc');
+      expect(box).toHaveStyle({ height: '20px' });
+    });
+
+    it('should scale positions when scale > 1', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      render(<BBO fields={mockFields} scale={1.5} />);
+
+      const box = screen.getByTestId('bbox-vendor_rfc');
+      // 100 * 1.5 = 150
+      expect(box).toHaveStyle({ left: '150px' });
+      // 50 * 1.5 = 75
+      expect(box).toHaveStyle({ top: '75px' });
+      // 200 * 1.5 = 300
+      expect(box).toHaveStyle({ width: '300px' });
+    });
+
+    it('should scale positions when scale < 1', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      render(<BBO fields={mockFields} scale={0.5} />);
+
+      const box = screen.getByTestId('bbox-vendor_rfc');
+      // 100 * 0.5 = 50
+      expect(box).toHaveStyle({ left: '50px' });
+      // 50 * 0.5 = 25
+      expect(box).toHaveStyle({ top: '25px' });
+    });
+  });
+
+  // ==========================================================================
+  // T016.2.4 - Confidence Color Tests
+  // ==========================================================================
+
+  describe('T016.2.4 - Color Boxes by Confidence Level', () => {
+    describe('T016.2.4.1 - Green for ≥90%', () => {
+      it('should have green border for confidence >= 90', async () => {
+        const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+        const { BoundingBoxOverlay: BBO } = module;
+
+        const highConfidenceFields = [
+          createField('high_conf', 95, { x: 0, y: 0, width: 100, height: 20 }),
+        ];
+
+        render(<BBO fields={highConfidenceFields} scale={1} />);
+
+        const box = screen.getByTestId('bbox-high_conf');
+        expect(box).toHaveClass('border-green-500');
+      });
+
+      it('should have green background with opacity for confidence >= 90', async () => {
+        const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+        const { BoundingBoxOverlay: BBO } = module;
+
+        const highConfidenceFields = [
+          createField('high_conf', 90, { x: 0, y: 0, width: 100, height: 20 }),
+        ];
+
+        render(<BBO fields={highConfidenceFields} scale={1} />);
+
+        const box = screen.getByTestId('bbox-high_conf');
+        expect(box).toHaveClass('bg-green-500/20');
+      });
+
+      it('should apply green to exactly 90% confidence', async () => {
+        const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+        const { BoundingBoxOverlay: BBO } = module;
+
+        const exactlyNinety = [
+          createField('exactly_90', 90, { x: 0, y: 0, width: 100, height: 20 }),
+        ];
+
+        render(<BBO fields={exactlyNinety} scale={1} />);
+
+        const box = screen.getByTestId('bbox-exactly_90');
+        expect(box).toHaveClass('border-green-500');
+      });
+    });
+
+    describe('T016.2.4.2 - Orange for 70-89%', () => {
+      it('should have orange border for confidence 70-89', async () => {
+        const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+        const { BoundingBoxOverlay: BBO } = module;
+
+        const mediumConfidenceFields = [
+          createField('medium_conf', 85, { x: 0, y: 0, width: 100, height: 20 }),
+        ];
+
+        render(<BBO fields={mediumConfidenceFields} scale={1} />);
+
+        const box = screen.getByTestId('bbox-medium_conf');
+        expect(box).toHaveClass('border-orange-500');
+      });
+
+      it('should have orange background with opacity for confidence 70-89', async () => {
+        const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+        const { BoundingBoxOverlay: BBO } = module;
+
+        const mediumConfidenceFields = [
+          createField('medium_conf', 75, { x: 0, y: 0, width: 100, height: 20 }),
+        ];
+
+        render(<BBO fields={mediumConfidenceFields} scale={1} />);
+
+        const box = screen.getByTestId('bbox-medium_conf');
+        expect(box).toHaveClass('bg-orange-500/20');
+      });
+
+      it('should apply orange to exactly 70% confidence', async () => {
+        const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+        const { BoundingBoxOverlay: BBO } = module;
+
+        const exactlySeventy = [
+          createField('exactly_70', 70, { x: 0, y: 0, width: 100, height: 20 }),
+        ];
+
+        render(<BBO fields={exactlySeventy} scale={1} />);
+
+        const box = screen.getByTestId('bbox-exactly_70');
+        expect(box).toHaveClass('border-orange-500');
+      });
+
+      it('should apply orange to 89% confidence (boundary)', async () => {
+        const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+        const { BoundingBoxOverlay: BBO } = module;
+
+        const eightyNine = [
+          createField('eighty_nine', 89, { x: 0, y: 0, width: 100, height: 20 }),
+        ];
+
+        render(<BBO fields={eightyNine} scale={1} />);
+
+        const box = screen.getByTestId('bbox-eighty_nine');
+        expect(box).toHaveClass('border-orange-500');
+      });
+    });
+
+    describe('T016.2.4.3 - Red for <70%', () => {
+      it('should have red border for confidence < 70', async () => {
+        const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+        const { BoundingBoxOverlay: BBO } = module;
+
+        const lowConfidenceFields = [
+          createField('low_conf', 60, { x: 0, y: 0, width: 100, height: 20 }),
+        ];
+
+        render(<BBO fields={lowConfidenceFields} scale={1} />);
+
+        const box = screen.getByTestId('bbox-low_conf');
+        expect(box).toHaveClass('border-red-500');
+      });
+
+      it('should have red background with opacity for confidence < 70', async () => {
+        const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+        const { BoundingBoxOverlay: BBO } = module;
+
+        const lowConfidenceFields = [
+          createField('low_conf', 45, { x: 0, y: 0, width: 100, height: 20 }),
+        ];
+
+        render(<BBO fields={lowConfidenceFields} scale={1} />);
+
+        const box = screen.getByTestId('bbox-low_conf');
+        expect(box).toHaveClass('bg-red-500/20');
+      });
+
+      it('should apply red to 69% confidence (boundary)', async () => {
+        const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+        const { BoundingBoxOverlay: BBO } = module;
+
+        const sixtyNine = [
+          createField('sixty_nine', 69, { x: 0, y: 0, width: 100, height: 20 }),
+        ];
+
+        render(<BBO fields={sixtyNine} scale={1} />);
+
+        const box = screen.getByTestId('bbox-sixty_nine');
+        expect(box).toHaveClass('border-red-500');
+      });
+
+      it('should apply red to very low confidence', async () => {
+        const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+        const { BoundingBoxOverlay: BBO } = module;
+
+        const veryLow = [
+          createField('very_low', 10, { x: 0, y: 0, width: 100, height: 20 }),
+        ];
+
+        render(<BBO fields={veryLow} scale={1} />);
+
+        const box = screen.getByTestId('bbox-very_low');
+        expect(box).toHaveClass('border-red-500');
+      });
+    });
+  });
+
+  // ==========================================================================
+  // T016.2.5 - Hover/Selection Highlight Tests
+  // ==========================================================================
+
+  describe('T016.2.5 - Highlight Active Field on Hover/Selection', () => {
+    it('should highlight box on hover', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      render(<BBO fields={mockFields} scale={1} />);
+
+      const box = screen.getByTestId('bbox-vendor_rfc');
+
+      fireEvent.mouseEnter(box);
+
+      expect(box).toHaveClass('ring-2');
+    });
+
+    it('should remove highlight on mouse leave', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      render(<BBO fields={mockFields} scale={1} />);
+
+      const box = screen.getByTestId('bbox-vendor_rfc');
+
+      fireEvent.mouseEnter(box);
+      expect(box).toHaveClass('ring-2');
+
+      fireEvent.mouseLeave(box);
+      expect(box).not.toHaveClass('ring-2');
+    });
+
+    it('should highlight selected field', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      render(<BBO fields={mockFields} scale={1} selectedField="vendor_name" />);
+
+      const selectedBox = screen.getByTestId('bbox-vendor_name');
+      expect(selectedBox).toHaveClass('ring-2');
+      expect(selectedBox).toHaveClass('ring-blue-500');
+    });
+
+    it('should not highlight non-selected fields', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      render(<BBO fields={mockFields} scale={1} selectedField="vendor_name" />);
+
+      const otherBox = screen.getByTestId('bbox-vendor_rfc');
+      expect(otherBox).not.toHaveClass('ring-blue-500');
+    });
+
+    it('should call onFieldClick when box is clicked', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      const onFieldClick = jest.fn();
+
+      render(<BBO fields={mockFields} scale={1} onFieldClick={onFieldClick} />);
+
+      const box = screen.getByTestId('bbox-vendor_rfc');
+      fireEvent.click(box);
+
+      expect(onFieldClick).toHaveBeenCalledWith('vendor_rfc');
+    });
+
+    it('should call onFieldHover when box is hovered', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      const onFieldHover = jest.fn();
+
+      render(<BBO fields={mockFields} scale={1} onFieldHover={onFieldHover} />);
+
+      const box = screen.getByTestId('bbox-vendor_rfc');
+      fireEvent.mouseEnter(box);
+
+      expect(onFieldHover).toHaveBeenCalledWith('vendor_rfc');
+    });
+
+    it('should call onFieldHover with null when mouse leaves', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      const onFieldHover = jest.fn();
+
+      render(<BBO fields={mockFields} scale={1} onFieldHover={onFieldHover} />);
+
+      const box = screen.getByTestId('bbox-vendor_rfc');
+      fireEvent.mouseEnter(box);
+      fireEvent.mouseLeave(box);
+
+      expect(onFieldHover).toHaveBeenLastCalledWith(null);
+    });
+
+    it('should show tooltip with field name on hover', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      render(<BBO fields={mockFields} scale={1} showTooltip />);
+
+      const box = screen.getByTestId('bbox-vendor_rfc');
+      fireEvent.mouseEnter(box);
+
+      expect(screen.getByTestId('bbox-tooltip')).toBeInTheDocument();
+      expect(screen.getByTestId('bbox-tooltip')).toHaveTextContent('vendor_rfc');
+    });
+  });
+
+  // ==========================================================================
+  // Tailwind Styling Tests
+  // ==========================================================================
+
+  describe('Tailwind Styling', () => {
+    it('should have border on boxes', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      render(<BBO fields={mockFields} scale={1} />);
+
+      const box = screen.getByTestId('bbox-vendor_rfc');
+      expect(box).toHaveClass('border-2');
+    });
+
+    it('should have pointer cursor on boxes', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      render(<BBO fields={mockFields} scale={1} />);
+
+      const box = screen.getByTestId('bbox-vendor_rfc');
+      expect(box).toHaveClass('cursor-pointer');
+    });
+
+    it('should have transition for smooth hover effects', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      render(<BBO fields={mockFields} scale={1} />);
+
+      const box = screen.getByTestId('bbox-vendor_rfc');
+      expect(box).toHaveClass('transition-all');
+    });
+
+    it('should position boxes absolutely within overlay', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      render(<BBO fields={mockFields} scale={1} />);
+
+      const box = screen.getByTestId('bbox-vendor_rfc');
+      expect(box).toHaveClass('absolute');
+    });
+  });
+
+  // ==========================================================================
+  // Edge Cases
+  // ==========================================================================
+
+  describe('Edge Cases', () => {
+    it('should handle empty fields array', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      expect(() => {
+        render(<BBO fields={[]} scale={1} />);
+      }).not.toThrow();
+
+      expect(screen.getByTestId('bbox-overlay')).toBeInTheDocument();
+    });
+
+    it('should handle zero confidence', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      const zeroConf = [
+        createField('zero_conf', 0, { x: 0, y: 0, width: 100, height: 20 }),
+      ];
+
+      render(<BBO fields={zeroConf} scale={1} />);
+
+      const box = screen.getByTestId('bbox-zero_conf');
+      expect(box).toHaveClass('border-red-500');
+    });
+
+    it('should handle 100% confidence', async () => {
+      const module = await import('../../../src/renderer/components/BoundingBoxOverlay');
+      const { BoundingBoxOverlay: BBO } = module;
+
+      const perfectConf = [
+        createField('perfect_conf', 100, { x: 0, y: 0, width: 100, height: 20 }),
+      ];
+
+      render(<BBO fields={perfectConf} scale={1} />);
+
+      const box = screen.getByTestId('bbox-perfect_conf');
+      expect(box).toHaveClass('border-green-500');
+    });
+  });
+});

--- a/log_files/T016.2_BoundingBoxOverlay_Log.md
+++ b/log_files/T016.2_BoundingBoxOverlay_Log.md
@@ -1,0 +1,96 @@
+# T016.2 Implementation Log: Bounding Box Overlay
+
+## Date: 2025-12-18
+
+## Task Description
+Implement bounding box overlay component that renders colored boxes over PDF to highlight extracted fields, with colors indicating confidence levels.
+
+## Subtasks Completed
+
+### T016.2.1 - Write test for bbox overlay
+Created comprehensive test suite with 38 tests covering:
+- Component structure and exports
+- Box rendering at correct positions
+- Scaling with zoom levels
+- Confidence-based coloring (green/orange/red)
+- Hover and selection highlighting
+- Click and hover callbacks
+- Tooltip display
+- Edge cases
+
+### T016.2.2 - Create BoundingBoxOverlay.tsx component
+- Created component in `src/renderer/components/`
+- Renders boxes for fields that have bbox property
+- Uses absolute positioning within overlay container
+
+### T016.2.3 - Render boxes at correct positions
+- Positions boxes using x, y, width, height from BoundingBox type
+- Scales all dimensions by current zoom factor
+- Positions match PDF coordinates
+
+### T016.2.4 - Color boxes by confidence level
+- **Green (≥90%)**: `border-green-500`, `bg-green-500/20`
+- **Orange (70-89%)**: `border-orange-500`, `bg-orange-500/20`
+- **Red (<70%)**: `border-red-500`, `bg-red-500/20`
+
+### T016.2.5 - Highlight active field on hover/selection
+- Ring highlight on mouse hover (`ring-2 ring-gray-400`)
+- Blue ring for selected field (`ring-2 ring-blue-500`)
+- `onFieldClick` callback for click handling
+- `onFieldHover` callback for hover tracking
+- Optional tooltip showing field name
+
+## Files Created
+- `desktop-app/src/renderer/components/BoundingBoxOverlay.tsx`
+- `desktop-app/tests/renderer/components/BoundingBoxOverlay.test.tsx`
+
+## Test Results
+- Total tests: 38
+- Passed: 38
+- Failed: 0
+
+## Component Usage Example
+```tsx
+import { BoundingBoxOverlay } from './components/BoundingBoxOverlay';
+
+function PDFWithHighlights({ fields, scale }) {
+  const [selectedField, setSelectedField] = useState<string | undefined>();
+
+  return (
+    <div className="relative">
+      <PDFViewer file={pdfUrl} scale={scale} />
+      <BoundingBoxOverlay
+        fields={fields}
+        scale={scale}
+        selectedField={selectedField}
+        onFieldClick={setSelectedField}
+        showTooltip
+      />
+    </div>
+  );
+}
+```
+
+## Props Interface
+```typescript
+interface BoundingBoxOverlayProps {
+  fields: ExtractionField[];
+  scale: number;
+  selectedField?: string;
+  onFieldClick?: (fieldName: string) => void;
+  onFieldHover?: (fieldName: string | null) => void;
+  showTooltip?: boolean;
+}
+```
+
+## Confidence Thresholds
+```typescript
+const CONFIDENCE_HIGH = 90;   // Green
+const CONFIDENCE_MEDIUM = 70; // Orange
+// Below 70 = Red
+```
+
+## Color Legend (as shown in UI)
+- 🟢 Green: High confidence (≥90%) - Can trust this value
+- 🟠 Orange: Medium confidence (70-89%) - May need review
+- 🔴 Red: Low confidence (<70%) - Requires verification

--- a/log_learn/T016.2_BoundingBoxOverlay_LearnLog.md
+++ b/log_learn/T016.2_BoundingBoxOverlay_LearnLog.md
@@ -1,0 +1,211 @@
+# T016.2 Learning Log: Bounding Box Overlay
+
+## Date: 2025-12-18
+
+## Key Learnings
+
+### 1. Absolute Positioning for Overlays
+Positioning boxes over PDF content:
+
+```tsx
+<div className="relative">
+  {/* PDF content */}
+  <PDFViewer file={url} />
+
+  {/* Overlay positioned absolutely on top */}
+  <div className="absolute inset-0 pointer-events-none">
+    {/* Boxes inside have pointer-events-auto */}
+    <div className="absolute" style={{ left: '100px', top: '50px' }}>
+      Box
+    </div>
+  </div>
+</div>
+```
+
+### 2. Scaling Coordinates with Zoom
+Adjusting box positions based on zoom level:
+
+```typescript
+const { x, y, width, height } = field.bbox;
+
+// Apply scale factor to all dimensions
+const scaledX = x * scale;
+const scaledY = y * scale;
+const scaledWidth = width * scale;
+const scaledHeight = height * scale;
+
+<div style={{
+  left: `${scaledX}px`,
+  top: `${scaledY}px`,
+  width: `${scaledWidth}px`,
+  height: `${scaledHeight}px`,
+}} />
+```
+
+### 3. Confidence-Based Color Coding
+Using thresholds for visual feedback:
+
+```typescript
+const CONFIDENCE_HIGH = 90;
+const CONFIDENCE_MEDIUM = 70;
+
+function getBorderColorClass(confidence: number): string {
+  if (confidence >= CONFIDENCE_HIGH) return 'border-green-500';
+  if (confidence >= CONFIDENCE_MEDIUM) return 'border-orange-500';
+  return 'border-red-500';
+}
+
+function getBackgroundColorClass(confidence: number): string {
+  if (confidence >= CONFIDENCE_HIGH) return 'bg-green-500/20';
+  if (confidence >= CONFIDENCE_MEDIUM) return 'bg-orange-500/20';
+  return 'bg-red-500/20';
+}
+```
+
+### 4. Tailwind Opacity Modifier
+Using slash notation for opacity:
+
+```tsx
+// Background with 20% opacity
+<div className="bg-green-500/20" />  // rgba(34, 197, 94, 0.2)
+<div className="bg-orange-500/20" /> // rgba(249, 115, 22, 0.2)
+<div className="bg-red-500/20" />    // rgba(239, 68, 68, 0.2)
+```
+
+### 5. Ring Utility for Focus/Selection
+Using Tailwind's ring for highlight effects:
+
+```tsx
+// Selected state
+<div className="ring-2 ring-blue-500" />
+
+// Hovered state
+<div className="ring-2 ring-gray-400" />
+
+// No ring
+<div className="" />
+```
+
+### 6. Pointer Events Control
+Allowing clicks to pass through overlay:
+
+```tsx
+// Parent overlay doesn't capture events
+<div className="pointer-events-none">
+  {/* Child boxes do capture events */}
+  <div className="pointer-events-auto">
+    Clickable box
+  </div>
+</div>
+```
+
+### 7. Conditional Class Application
+Applying classes based on state:
+
+```typescript
+const ringClasses = isSelected
+  ? 'ring-2 ring-blue-500'
+  : isHovered
+  ? 'ring-2 ring-gray-400'
+  : '';
+
+<div className={`border-2 ${borderColor} ${ringClasses}`} />
+```
+
+### 8. Hover State Management
+Tracking hover with useState:
+
+```typescript
+const [hoveredField, setHoveredField] = useState<string | null>(null);
+
+const handleMouseEnter = (fieldName: string) => {
+  setHoveredField(fieldName);
+  onFieldHover?.(fieldName);
+};
+
+const handleMouseLeave = () => {
+  setHoveredField(null);
+  onFieldHover?.(null);
+};
+```
+
+### 9. Tooltip Positioning
+Positioning tooltip above the box:
+
+```tsx
+{showTooltip && isHovered && (
+  <div
+    className="
+      absolute
+      bottom-full    /* Position above the box */
+      left-0
+      mb-1          /* Small gap */
+      px-2 py-1
+      bg-gray-800
+      text-white
+      text-xs
+      rounded
+      whitespace-nowrap
+      z-10
+    "
+  >
+    {field.fieldName}
+  </div>
+)}
+```
+
+### 10. Testing Style Attributes
+Testing inline styles with Jest:
+
+```typescript
+it('should position box at correct x coordinate', () => {
+  render(<BoundingBoxOverlay fields={fields} scale={1} />);
+
+  const box = screen.getByTestId('bbox-vendor_rfc');
+  expect(box).toHaveStyle({ left: '100px' });
+});
+
+it('should scale positions', () => {
+  render(<BoundingBoxOverlay fields={fields} scale={1.5} />);
+
+  const box = screen.getByTestId('bbox-vendor_rfc');
+  // 100 * 1.5 = 150
+  expect(box).toHaveStyle({ left: '150px' });
+});
+```
+
+### 11. Testing Tailwind Classes
+Verifying Tailwind classes are applied:
+
+```typescript
+it('should have green border for high confidence', () => {
+  const highConf = [createField('high', 95, bbox)];
+  render(<BoundingBoxOverlay fields={highConf} scale={1} />);
+
+  const box = screen.getByTestId('bbox-high');
+  expect(box).toHaveClass('border-green-500');
+  expect(box).toHaveClass('bg-green-500/20');
+});
+```
+
+### 12. Transition for Smooth Effects
+Adding smooth transitions:
+
+```tsx
+<div className="
+  transition-all
+  duration-150
+  border-2
+  cursor-pointer
+" />
+```
+
+## Files Referenced
+- `desktop-app/src/renderer/components/BoundingBoxOverlay.tsx`
+- `desktop-app/tests/renderer/components/BoundingBoxOverlay.test.tsx`
+- `desktop-app/src/renderer/types/index.ts`
+
+## Related Documentation
+- [Tailwind CSS Ring](https://tailwindcss.com/docs/ring-width)
+- [Tailwind CSS Opacity](https://tailwindcss.com/docs/background-color#changing-the-opacity)
+- [Tailwind CSS Pointer Events](https://tailwindcss.com/docs/pointer-events)

--- a/log_tests/T016.2_BoundingBoxOverlay_TestLog.md
+++ b/log_tests/T016.2_BoundingBoxOverlay_TestLog.md
@@ -1,0 +1,125 @@
+# T016.2 Test Log: Bounding Box Overlay
+
+## Date: 2025-12-18
+
+## Test File
+`desktop-app/tests/renderer/components/BoundingBoxOverlay.test.tsx`
+
+## Test Summary
+- **Total Tests**: 38
+- **Passed**: 38
+- **Skipped**: 0
+- **Failed**: 0
+
+## Test Categories
+
+### Component Structure Tests (4 tests)
+| Test | Status |
+|------|--------|
+| should export BoundingBoxOverlay component | PASS |
+| should render without crashing | PASS |
+| should render overlay container | PASS |
+| should have absolute positioning | PASS |
+
+### Box Rendering Tests (8 tests)
+| Test | Status |
+|------|--------|
+| should render a box for each field with bbox | PASS |
+| should not render box for field without bbox | PASS |
+| should position box at correct x coordinate | PASS |
+| should position box at correct y coordinate | PASS |
+| should set box width correctly | PASS |
+| should set box height correctly | PASS |
+| should scale positions when scale > 1 | PASS |
+| should scale positions when scale < 1 | PASS |
+
+### Green Confidence Tests (3 tests)
+| Test | Status |
+|------|--------|
+| should have green border for confidence >= 90 | PASS |
+| should have green background with opacity | PASS |
+| should apply green to exactly 90% confidence | PASS |
+
+### Orange Confidence Tests (4 tests)
+| Test | Status |
+|------|--------|
+| should have orange border for confidence 70-89 | PASS |
+| should have orange background with opacity | PASS |
+| should apply orange to exactly 70% confidence | PASS |
+| should apply orange to 89% confidence (boundary) | PASS |
+
+### Red Confidence Tests (4 tests)
+| Test | Status |
+|------|--------|
+| should have red border for confidence < 70 | PASS |
+| should have red background with opacity | PASS |
+| should apply red to 69% confidence (boundary) | PASS |
+| should apply red to very low confidence | PASS |
+
+### Hover/Selection Tests (8 tests)
+| Test | Status |
+|------|--------|
+| should highlight box on hover | PASS |
+| should remove highlight on mouse leave | PASS |
+| should highlight selected field | PASS |
+| should not highlight non-selected fields | PASS |
+| should call onFieldClick when box is clicked | PASS |
+| should call onFieldHover when box is hovered | PASS |
+| should call onFieldHover with null on leave | PASS |
+| should show tooltip with field name on hover | PASS |
+
+### Tailwind Styling Tests (4 tests)
+| Test | Status |
+|------|--------|
+| should have border on boxes | PASS |
+| should have pointer cursor on boxes | PASS |
+| should have transition for smooth effects | PASS |
+| should position boxes absolutely | PASS |
+
+### Edge Case Tests (3 tests)
+| Test | Status |
+|------|--------|
+| should handle empty fields array | PASS |
+| should handle zero confidence | PASS |
+| should handle 100% confidence | PASS |
+
+## Test Data Setup
+```typescript
+const createField = (
+  fieldName: string,
+  confidence: number,
+  bbox: BoundingBox
+): ExtractionField => ({
+  fieldName,
+  value: `Value for ${fieldName}`,
+  confidence,
+  bbox,
+  userVerified: false,
+});
+
+const mockFields: ExtractionField[] = [
+  createField('vendor_rfc', 95, { x: 100, y: 50, width: 200, height: 20 }),
+  createField('vendor_name', 85, { x: 100, y: 80, width: 250, height: 20 }),
+  createField('invoice_number', 60, { x: 400, y: 50, width: 100, height: 20 }),
+  createField('total', 92, { x: 400, y: 200, width: 80, height: 25 }),
+];
+```
+
+## Test Commands
+```bash
+# Run BoundingBoxOverlay tests only
+cd desktop-app
+npm test -- tests/renderer/components/BoundingBoxOverlay.test.tsx -v
+
+# Run all component tests
+npm test -- tests/renderer/components/ -v
+```
+
+## Total Desktop App Tests
+- T010.1: 28 tests (StatusBar)
+- T010.2: 24 tests (useServiceStatus hook)
+- T015.1: 35 tests (AI service client)
+- T015.2: 32 tests (FileUpload)
+- T016.1: 34 tests (PDFViewer)
+- T016.2: 38 tests (BoundingBoxOverlay)
+- **Total: 191 tests**

--- a/specs/001-windows-native-ai/tasks.md
+++ b/specs/001-windows-native-ai/tasks.md
@@ -1017,17 +1017,27 @@
   - Error message display support
   - 34 tests covering rendering, zoom, navigation, and styling
 
-- [ ] **T016.2** Implement bounding box overlay
-  - [ ] T016.2.1 [P] Write test for bbox overlay
-  - [ ] T016.2.2 Create `BoundingBoxOverlay.tsx` component
-  - [ ] T016.2.3 Render boxes at correct positions
-  - [ ] T016.2.4 Color boxes by confidence level
-    - [ ] T016.2.4.1 Green for ≥90%
-    - [ ] T016.2.4.2 Orange for 70-89%
-    - [ ] T016.2.4.3 Red for <70%
-  - [ ] T016.2.5 Highlight active field on hover/selection
+- [x] **T016.2** Implement bounding box overlay ✅ 2025-12-18
+  - [x] T016.2.1 [P] Write test for bbox overlay (38 tests)
+  - [x] T016.2.2 Create `BoundingBoxOverlay.tsx` component
+  - [x] T016.2.3 Render boxes at correct positions
+  - [x] T016.2.4 Color boxes by confidence level
+    - [x] T016.2.4.1 Green for ≥90%
+    - [x] T016.2.4.2 Orange for 70-89%
+    - [x] T016.2.4.3 Red for <70%
+  - [x] T016.2.5 Highlight active field on hover/selection
 
-**Checkpoint**: PDF displays with extraction highlights
+  **Implementation Details:**
+  - Created `BoundingBoxOverlay` component in `desktop-app/src/renderer/components/`
+  - Renders absolute-positioned boxes for fields with bbox property
+  - Scales coordinates with zoom: `x * scale`, `y * scale`, etc.
+  - Confidence colors: green (≥90%), orange (70-89%), red (<70%)
+  - Background opacity: `bg-{color}-500/20` for semi-transparent fill
+  - Ring highlight on hover/selection with smooth transitions
+  - Optional tooltip showing field name on hover
+  - 38 tests covering positioning, colors, interactions, and edge cases
+
+**Checkpoint**: PDF displays with extraction highlights ✅
 
 ---
 


### PR DESCRIPTION
- Create BoundingBoxOverlay component for highlighting extracted fields
- Render boxes at correct positions with zoom scaling support
- Color boxes by confidence: green (≥90%), orange (70-89%), red (<70%)
- Implement hover/selection highlighting with ring utility
- Add optional tooltip showing field name on hover
- Add 38 comprehensive tests covering all features