### PR TITLE
feat(T019.1): implement FieldInput component with inline editing

### DIFF
--- a/desktop-app/src/renderer/components/FieldInput.tsx
+++ b/desktop-app/src/renderer/components/FieldInput.tsx
@@ -1,0 +1,333 @@
+/**
+ * T019.1 - FieldInput Component
+ *
+ * Editable input field for invoice extraction data that:
+ * - Displays field label, value, and confidence indicator
+ * - Enables inline editing on click
+ * - Marks field as "user_verified" after edit
+ * - Validates input format (RFC, date, amounts)
+ *
+ * Uses Tailwind CSS for styling.
+ */
+
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { ConfidenceIndicator } from './ConfidenceIndicator';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Field types for validation
+ */
+export type FieldType = 'text' | 'rfc' | 'date' | 'amount';
+
+/**
+ * Props for FieldInput component
+ */
+export interface FieldInputProps {
+  /** Field label (e.g., "RFC del Proveedor") */
+  label: string;
+  /** Current field value */
+  value: string;
+  /** Confidence score (0-100) */
+  confidence: number;
+  /** Field type for validation */
+  fieldType?: FieldType;
+  /** Whether the value has been verified by user */
+  userVerified?: boolean;
+  /** Whether the field is read-only */
+  readOnly?: boolean;
+  /** Whether the field is currently selected */
+  isSelected?: boolean;
+  /** Callback when value changes: (newValue, userVerified) */
+  onChange: (value: string, userVerified: boolean) => void;
+  /** Callback when field is selected */
+  onSelect?: () => void;
+}
+
+// =============================================================================
+// Validation Functions
+// =============================================================================
+
+/**
+ * Validate RFC format (12 or 13 alphanumeric characters)
+ */
+function validateRfc(value: string): boolean {
+  // RFC can be 12 (company) or 13 (individual) characters
+  const rfcRegex = /^[A-Za-z0-9]{12,13}$/;
+  return rfcRegex.test(value.trim());
+}
+
+/**
+ * Validate date format (YYYY-MM-DD or DD/MM/YYYY)
+ */
+function validateDate(value: string): boolean {
+  // ISO format: YYYY-MM-DD
+  const isoRegex = /^\d{4}-\d{2}-\d{2}$/;
+  // Mexican format: DD/MM/YYYY
+  const mxRegex = /^\d{2}\/\d{2}\/\d{4}$/;
+
+  if (isoRegex.test(value)) {
+    const date = new Date(value);
+    return !isNaN(date.getTime());
+  }
+
+  if (mxRegex.test(value)) {
+    const [day, month, year] = value.split('/').map(Number);
+    const date = new Date(year, month - 1, day);
+    return !isNaN(date.getTime()) && date.getDate() === day;
+  }
+
+  return false;
+}
+
+/**
+ * Validate amount format (decimal number, optional comma separators)
+ */
+function validateAmount(value: string): boolean {
+  // Remove commas for validation
+  const cleanValue = value.replace(/,/g, '');
+  // Allow negative numbers, decimals
+  const amountRegex = /^-?\d+(\.\d{0,2})?$/;
+  return amountRegex.test(cleanValue);
+}
+
+/**
+ * Validate value based on field type
+ */
+function validateValue(value: string, fieldType: FieldType): string | null {
+  if (!value.trim()) return null; // Empty values are allowed
+
+  switch (fieldType) {
+    case 'rfc':
+      return validateRfc(value) ? null : 'RFC debe tener 12 o 13 caracteres alfanuméricos';
+    case 'date':
+      return validateDate(value) ? null : 'Formato de fecha inválido (use YYYY-MM-DD o DD/MM/YYYY)';
+    case 'amount':
+      return validateAmount(value) ? null : 'Monto inválido (use números con hasta 2 decimales)';
+    case 'text':
+    default:
+      return null; // No validation for text
+  }
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * FieldInput component for editable invoice fields
+ *
+ * @example
+ * ```tsx
+ * <FieldInput
+ *   label="RFC del Proveedor"
+ *   value="ABC123456DEF"
+ *   confidence={95}
+ *   fieldType="rfc"
+ *   onChange={(value, verified) => handleChange(value, verified)}
+ * />
+ * ```
+ */
+export function FieldInput({
+  label,
+  value,
+  confidence,
+  fieldType = 'text',
+  userVerified = false,
+  readOnly = false,
+  isSelected = false,
+  onChange,
+  onSelect,
+}: FieldInputProps): JSX.Element {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState(value);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [isHovered, setIsHovered] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Update edit value when prop value changes
+  useEffect(() => {
+    if (!isEditing) {
+      setEditValue(value);
+    }
+  }, [value, isEditing]);
+
+  // Focus input when entering edit mode
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditing]);
+
+  /**
+   * Enter edit mode
+   */
+  const startEditing = useCallback(() => {
+    if (readOnly) return;
+    setIsEditing(true);
+    setEditValue(value);
+    setValidationError(null);
+  }, [readOnly, value]);
+
+  /**
+   * Save the edited value
+   */
+  const saveValue = useCallback(() => {
+    const trimmedValue = editValue.trim();
+
+    // Validate
+    const error = validateValue(trimmedValue, fieldType);
+    if (error) {
+      setValidationError(error);
+      return;
+    }
+
+    // Only call onChange if value actually changed
+    if (trimmedValue !== value) {
+      onChange(trimmedValue, true);
+    }
+
+    setIsEditing(false);
+    setValidationError(null);
+  }, [editValue, fieldType, value, onChange]);
+
+  /**
+   * Cancel editing and restore original value
+   */
+  const cancelEdit = useCallback(() => {
+    setIsEditing(false);
+    setEditValue(value);
+    setValidationError(null);
+  }, [value]);
+
+  /**
+   * Handle key press in input
+   */
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        saveValue();
+      } else if (e.key === 'Escape') {
+        cancelEdit();
+      }
+    },
+    [saveValue, cancelEdit]
+  );
+
+  /**
+   * Handle input blur
+   */
+  const handleBlur = useCallback(() => {
+    // Small delay to allow button clicks to register
+    setTimeout(() => {
+      if (isEditing) {
+        saveValue();
+      }
+    }, 100);
+  }, [isEditing, saveValue]);
+
+  /**
+   * Handle container click
+   */
+  const handleContainerClick = useCallback(() => {
+    if (onSelect) {
+      onSelect();
+    }
+  }, [onSelect]);
+
+  // Determine container classes
+  const containerClasses = [
+    'border rounded p-2 transition-all duration-150',
+    'hover:bg-gray-50 hover:border-gray-300',
+    isSelected ? 'ring-2 ring-blue-500 border-blue-500' : 'border-gray-200',
+    readOnly ? 'cursor-default' : 'cursor-pointer',
+  ].join(' ');
+
+  return (
+    <div
+      data-testid="field-input"
+      className={containerClasses}
+      onClick={handleContainerClick}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      {/* Header: Label + Confidence + Verified Badge */}
+      <div className="flex items-center justify-between mb-1">
+        <label className="text-xs text-gray-500 font-medium">{label}</label>
+        <div className="flex items-center gap-2">
+          <ConfidenceIndicator confidence={confidence} size="sm" />
+          {userVerified && (
+            <span
+              data-testid="verified-badge"
+              className="text-xs bg-green-100 text-green-700 px-1.5 py-0.5 rounded"
+            >
+              ✓ Verificado
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Value Display / Edit Mode */}
+      {isEditing ? (
+        <div data-testid="field-input-edit" className="relative">
+          <input
+            ref={inputRef}
+            type="text"
+            value={editValue}
+            onChange={(e) => {
+              setEditValue(e.target.value);
+              setValidationError(null);
+            }}
+            onKeyDown={handleKeyDown}
+            onBlur={handleBlur}
+            className={`w-full px-2 py-1 text-sm border rounded focus:outline-none focus:ring-2 ${
+              validationError
+                ? 'border-red-500 focus:ring-red-500'
+                : 'border-blue-500 focus:ring-blue-500'
+            }`}
+          />
+          {validationError && (
+            <div
+              data-testid="validation-error"
+              className="text-xs text-red-600 mt-1"
+            >
+              {validationError}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="flex items-center justify-between">
+          <div
+            data-testid="field-value"
+            onClick={(e) => {
+              e.stopPropagation();
+              startEditing();
+            }}
+            className="text-sm font-medium text-gray-900 flex-1"
+          >
+            {value || (
+              <span className="text-gray-400 italic">Sin valor</span>
+            )}
+          </div>
+          {isHovered && !readOnly && (
+            <button
+              data-testid="edit-button"
+              onClick={(e) => {
+                e.stopPropagation();
+                startEditing();
+              }}
+              className="text-xs text-blue-600 hover:text-blue-800 ml-2"
+            >
+              Editar
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default FieldInput;

--- a/desktop-app/tests/renderer/components/FieldInput.test.tsx
+++ b/desktop-app/tests/renderer/components/FieldInput.test.tsx
@@ -1,0 +1,799 @@
+/**
+ * T019.1 - FieldInput Component Tests
+ *
+ * Tests for the field input component that:
+ * - Displays field label, value, and confidence indicator
+ * - Enables inline editing on click
+ * - Marks field as "user_verified" after edit
+ * - Validates input format (RFC, date, amounts)
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+// Will be created in T019.1.2
+let FieldInput: typeof import('../../../src/renderer/components/FieldInput').FieldInput;
+
+// Mock ConfidenceIndicator
+jest.mock('../../../src/renderer/components/ConfidenceIndicator', () => ({
+  ConfidenceIndicator: ({ confidence }: { confidence: number }) => (
+    <div data-testid="confidence-indicator" data-confidence={confidence}>
+      Confidence: {confidence}%
+    </div>
+  ),
+}));
+
+describe('T019.1 - FieldInput Component', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module = await import('../../../src/renderer/components/FieldInput');
+    FieldInput = module.FieldInput;
+  });
+
+  // ==========================================================================
+  // T019.1.1 - Component Structure Tests
+  // ==========================================================================
+
+  describe('T019.1.1 - Component Structure', () => {
+    it('should export FieldInput component', async () => {
+      const module = await import('../../../src/renderer/components/FieldInput');
+      expect(module.FieldInput).toBeDefined();
+      expect(typeof module.FieldInput).toBe('function');
+    });
+
+    it('should render without crashing', () => {
+      expect(() => {
+        render(
+          <FieldInput
+            label="RFC"
+            value="ABC123456DEF"
+            confidence={95}
+            onChange={() => {}}
+          />
+        );
+      }).not.toThrow();
+    });
+
+    it('should render field container', () => {
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={95}
+          onChange={() => {}}
+        />
+      );
+      expect(screen.getByTestId('field-input')).toBeInTheDocument();
+    });
+  });
+
+  // ==========================================================================
+  // T019.1.2 - Display Field Label, Value, Confidence
+  // ==========================================================================
+
+  describe('T019.1.2 - Display Field Information', () => {
+    it('should display field label', () => {
+      render(
+        <FieldInput
+          label="RFC del Proveedor"
+          value="ABC123456DEF"
+          confidence={95}
+          onChange={() => {}}
+        />
+      );
+      expect(screen.getByText('RFC del Proveedor')).toBeInTheDocument();
+    });
+
+    it('should display field value', () => {
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={95}
+          onChange={() => {}}
+        />
+      );
+      expect(screen.getByText('ABC123456DEF')).toBeInTheDocument();
+    });
+
+    it('should display confidence indicator', () => {
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={85}
+          onChange={() => {}}
+        />
+      );
+      const indicator = screen.getByTestId('confidence-indicator');
+      expect(indicator).toBeInTheDocument();
+      expect(indicator).toHaveAttribute('data-confidence', '85');
+    });
+
+    it('should display empty value placeholder', () => {
+      render(
+        <FieldInput
+          label="RFC"
+          value=""
+          confidence={0}
+          onChange={() => {}}
+        />
+      );
+      expect(screen.getByText('Sin valor')).toBeInTheDocument();
+    });
+  });
+
+  // ==========================================================================
+  // T019.1.3 - User Verified Badge
+  // ==========================================================================
+
+  describe('T019.1.3 - User Verified Badge', () => {
+    it('should not show verified badge by default', () => {
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={95}
+          onChange={() => {}}
+        />
+      );
+      expect(screen.queryByTestId('verified-badge')).not.toBeInTheDocument();
+    });
+
+    it('should show verified badge when userVerified is true', () => {
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={95}
+          userVerified
+          onChange={() => {}}
+        />
+      );
+      expect(screen.getByTestId('verified-badge')).toBeInTheDocument();
+    });
+
+    it('should display checkmark in verified badge', () => {
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={95}
+          userVerified
+          onChange={() => {}}
+        />
+      );
+      const badge = screen.getByTestId('verified-badge');
+      expect(badge).toHaveTextContent(/✓|verificado/i);
+    });
+  });
+
+  // ==========================================================================
+  // T019.1.4 - Inline Editing
+  // ==========================================================================
+
+  describe('T019.1.4 - Inline Editing', () => {
+    it('should show edit button on hover', async () => {
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={95}
+          onChange={() => {}}
+        />
+      );
+      const container = screen.getByTestId('field-input');
+      fireEvent.mouseEnter(container);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('edit-button')).toBeInTheDocument();
+      });
+    });
+
+    it('should enter edit mode on click', async () => {
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={95}
+          onChange={() => {}}
+        />
+      );
+
+      // Click on value to edit
+      const valueDisplay = screen.getByTestId('field-value');
+      fireEvent.click(valueDisplay);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('field-input-edit')).toBeInTheDocument();
+      });
+    });
+
+    it('should show input field in edit mode', async () => {
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={95}
+          onChange={() => {}}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('field-value'));
+
+      await waitFor(() => {
+        const input = screen.getByRole('textbox');
+        expect(input).toBeInTheDocument();
+        expect(input).toHaveValue('ABC123456DEF');
+      });
+    });
+
+    it('should focus input when entering edit mode', async () => {
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={95}
+          onChange={() => {}}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('field-value'));
+
+      await waitFor(() => {
+        const input = screen.getByRole('textbox');
+        expect(input).toHaveFocus();
+      });
+    });
+
+    it('should save value on Enter key', async () => {
+      const handleChange = jest.fn();
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={95}
+          onChange={handleChange}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('field-value'));
+
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'XYZ789012GHI' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalledWith('XYZ789012GHI', true);
+      });
+    });
+
+    it('should cancel edit on Escape key', async () => {
+      const handleChange = jest.fn();
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={95}
+          onChange={handleChange}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('field-value'));
+
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'XYZ789012GHI' } });
+      fireEvent.keyDown(input, { key: 'Escape' });
+
+      await waitFor(() => {
+        expect(handleChange).not.toHaveBeenCalled();
+        expect(screen.getByText('ABC123456DEF')).toBeInTheDocument();
+      });
+    });
+
+    it('should save value on blur', async () => {
+      const handleChange = jest.fn();
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={95}
+          onChange={handleChange}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('field-value'));
+
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'XYZ789012GHI' } });
+      fireEvent.blur(input);
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalledWith('XYZ789012GHI', true);
+      });
+    });
+  });
+
+  // ==========================================================================
+  // T019.1.5 - Mark as User Verified After Edit
+  // ==========================================================================
+
+  describe('T019.1.5 - Mark as User Verified', () => {
+    it('should pass userVerified=true when value is changed', async () => {
+      const handleChange = jest.fn();
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={95}
+          onChange={handleChange}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('field-value'));
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'NEW_VALUE' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalledWith('NEW_VALUE', true);
+      });
+    });
+
+    it('should not call onChange if value unchanged', async () => {
+      const handleChange = jest.fn();
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={95}
+          onChange={handleChange}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('field-value'));
+      const input = screen.getByRole('textbox');
+      // Don't change the value
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(handleChange).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  // ==========================================================================
+  // T019.1.6 - Input Validation
+  // ==========================================================================
+
+  describe('T019.1.6 - RFC Validation', () => {
+    it('should validate RFC format (12 or 13 chars)', async () => {
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={95}
+          fieldType="rfc"
+          onChange={() => {}}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('field-value'));
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'INVALID' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('validation-error')).toBeInTheDocument();
+      });
+    });
+
+    it('should accept valid 12-char RFC', async () => {
+      const handleChange = jest.fn();
+      render(
+        <FieldInput
+          label="RFC"
+          value=""
+          confidence={0}
+          fieldType="rfc"
+          onChange={handleChange}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('field-value'));
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'ABC123456DEF' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalled();
+        expect(screen.queryByTestId('validation-error')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should accept valid 13-char RFC', async () => {
+      const handleChange = jest.fn();
+      render(
+        <FieldInput
+          label="RFC"
+          value=""
+          confidence={0}
+          fieldType="rfc"
+          onChange={handleChange}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('field-value'));
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'ABCD123456EFG' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('T019.1.6 - Date Validation', () => {
+    it('should validate date format', async () => {
+      render(
+        <FieldInput
+          label="Fecha"
+          value="2025-12-15"
+          confidence={90}
+          fieldType="date"
+          onChange={() => {}}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('field-value'));
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'not-a-date' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('validation-error')).toBeInTheDocument();
+      });
+    });
+
+    it('should accept valid ISO date', async () => {
+      const handleChange = jest.fn();
+      render(
+        <FieldInput
+          label="Fecha"
+          value=""
+          confidence={0}
+          fieldType="date"
+          onChange={handleChange}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('field-value'));
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: '2025-12-15' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalled();
+      });
+    });
+
+    it('should accept DD/MM/YYYY format', async () => {
+      const handleChange = jest.fn();
+      render(
+        <FieldInput
+          label="Fecha"
+          value=""
+          confidence={0}
+          fieldType="date"
+          onChange={handleChange}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('field-value'));
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: '15/12/2025' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('T019.1.6 - Amount Validation', () => {
+    it('should validate amount format', async () => {
+      render(
+        <FieldInput
+          label="Total"
+          value="1000.00"
+          confidence={88}
+          fieldType="amount"
+          onChange={() => {}}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('field-value'));
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'abc' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('validation-error')).toBeInTheDocument();
+      });
+    });
+
+    it('should accept valid decimal amount', async () => {
+      const handleChange = jest.fn();
+      render(
+        <FieldInput
+          label="Total"
+          value=""
+          confidence={0}
+          fieldType="amount"
+          onChange={handleChange}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('field-value'));
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: '1234.56' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalled();
+      });
+    });
+
+    it('should accept amount with comma separator', async () => {
+      const handleChange = jest.fn();
+      render(
+        <FieldInput
+          label="Total"
+          value=""
+          confidence={0}
+          fieldType="amount"
+          onChange={handleChange}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('field-value'));
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: '1,234.56' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalled();
+      });
+    });
+
+    it('should accept negative amounts', async () => {
+      const handleChange = jest.fn();
+      render(
+        <FieldInput
+          label="Total"
+          value=""
+          confidence={0}
+          fieldType="amount"
+          onChange={handleChange}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('field-value'));
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: '-100.00' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('T019.1.6 - Text Field (No Validation)', () => {
+    it('should accept any text for text field type', async () => {
+      const handleChange = jest.fn();
+      render(
+        <FieldInput
+          label="Nombre"
+          value=""
+          confidence={0}
+          fieldType="text"
+          onChange={handleChange}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('field-value'));
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'Any text here!' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalled();
+        expect(screen.queryByTestId('validation-error')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should default to text type if fieldType not specified', async () => {
+      const handleChange = jest.fn();
+      render(
+        <FieldInput
+          label="Campo"
+          value=""
+          confidence={0}
+          onChange={handleChange}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('field-value'));
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'Any value' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalled();
+      });
+    });
+  });
+
+  // ==========================================================================
+  // Tailwind Styling Tests
+  // ==========================================================================
+
+  describe('Tailwind Styling', () => {
+    it('should have border styling', () => {
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={95}
+          onChange={() => {}}
+        />
+      );
+      const container = screen.getByTestId('field-input');
+      expect(container).toHaveClass('border');
+    });
+
+    it('should have rounded corners', () => {
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={95}
+          onChange={() => {}}
+        />
+      );
+      const container = screen.getByTestId('field-input');
+      expect(container).toHaveClass('rounded');
+    });
+
+    it('should have padding', () => {
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={95}
+          onChange={() => {}}
+        />
+      );
+      const container = screen.getByTestId('field-input');
+      expect(container.className).toMatch(/p-\d/);
+    });
+
+    it('should have hover state', () => {
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={95}
+          onChange={() => {}}
+        />
+      );
+      const container = screen.getByTestId('field-input');
+      expect(container.className).toMatch(/hover:/);
+    });
+
+    it('should style validation error in red', async () => {
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={95}
+          fieldType="rfc"
+          onChange={() => {}}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('field-value'));
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: 'X' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        const error = screen.getByTestId('validation-error');
+        expect(error.className).toMatch(/text-red/);
+      });
+    });
+  });
+
+  // ==========================================================================
+  // Read-only Mode Tests
+  // ==========================================================================
+
+  describe('Read-only Mode', () => {
+    it('should not allow editing when readOnly is true', () => {
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={95}
+          readOnly
+          onChange={() => {}}
+        />
+      );
+
+      const valueDisplay = screen.getByTestId('field-value');
+      fireEvent.click(valueDisplay);
+
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    });
+
+    it('should not show edit button when readOnly', () => {
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={95}
+          readOnly
+          onChange={() => {}}
+        />
+      );
+
+      const container = screen.getByTestId('field-input');
+      fireEvent.mouseEnter(container);
+
+      expect(screen.queryByTestId('edit-button')).not.toBeInTheDocument();
+    });
+  });
+
+  // ==========================================================================
+  // Field Selection Callback Tests
+  // ==========================================================================
+
+  describe('Field Selection', () => {
+    it('should call onSelect when field is clicked', () => {
+      const handleSelect = jest.fn();
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={95}
+          onChange={() => {}}
+          onSelect={handleSelect}
+        />
+      );
+
+      const container = screen.getByTestId('field-input');
+      fireEvent.click(container);
+
+      expect(handleSelect).toHaveBeenCalled();
+    });
+
+    it('should highlight when selected', () => {
+      render(
+        <FieldInput
+          label="RFC"
+          value="ABC123456DEF"
+          confidence={95}
+          isSelected
+          onChange={() => {}}
+        />
+      );
+
+      const container = screen.getByTestId('field-input');
+      expect(container.className).toMatch(/ring|border-blue/);
+    });
+  });
+});

--- a/log_files/T019.1_FieldInput_Log.md
+++ b/log_files/T019.1_FieldInput_Log.md
@@ -1,0 +1,108 @@
+# T019.1 Implementation Log: Field Input Component
+
+## Date: 2025-12-18
+
+## Task Description
+Create a reusable field input component for invoice extraction data that displays value with confidence, enables inline editing, validates input, and marks edited fields as user-verified.
+
+## Subtasks Completed
+
+### T019.1.1 - Write test for field input
+Created comprehensive test suite with 40 tests covering:
+- Component structure and exports
+- Display of label, value, confidence indicator
+- User verified badge display
+- Inline editing (enter/exit modes, keyboard handling)
+- Save on Enter, cancel on Escape, save on blur
+- Mark as user_verified after edit
+- Validation for RFC, date, and amount formats
+- Text field with no validation
+- Tailwind styling
+- Read-only mode
+- Field selection callbacks
+
+### T019.1.2 - Create FieldInput.tsx component
+- Created component in `src/renderer/components/`
+- Props: label, value, confidence, fieldType, userVerified, readOnly, isSelected, onChange, onSelect
+- Uses ConfidenceIndicator component for confidence display
+
+### T019.1.3 - Display field label, value, confidence
+- Label displayed as gray text above value
+- Value displayed prominently
+- "Sin valor" placeholder for empty values
+- ConfidenceIndicator shows colored dot
+
+### T019.1.4 - Enable inline editing on click
+- Click on value enters edit mode
+- Input auto-focused and text selected
+- Edit button appears on hover
+- Enter key saves, Escape cancels
+- Blur saves (with small delay for button clicks)
+
+### T019.1.5 - Mark field as "user_verified" after edit
+- onChange callback receives (newValue, userVerified)
+- userVerified=true when value is changed
+- Verified badge shows "✓ Verificado" in green
+
+### T019.1.6 - Validate input format
+- **RFC**: 12-13 alphanumeric characters
+- **Date**: YYYY-MM-DD or DD/MM/YYYY formats
+- **Amount**: Decimal numbers, optional commas, negatives allowed
+- **Text**: No validation (default)
+
+## Files Created
+- `desktop-app/src/renderer/components/FieldInput.tsx`
+- `desktop-app/tests/renderer/components/FieldInput.test.tsx`
+
+## Test Results
+- Total tests: 40
+- Passed: 40
+- Failed: 0
+
+## Component Usage Example
+```tsx
+import { FieldInput } from './components/FieldInput';
+
+function InvoiceForm({ extraction }) {
+  const [rfc, setRfc] = useState(extraction.vendorRfc.value);
+  const [rfcVerified, setRfcVerified] = useState(extraction.vendorRfc.userVerified);
+
+  return (
+    <FieldInput
+      label="RFC del Proveedor"
+      value={rfc}
+      confidence={extraction.vendorRfc.confidence}
+      fieldType="rfc"
+      userVerified={rfcVerified}
+      onChange={(newValue, verified) => {
+        setRfc(newValue);
+        setRfcVerified(verified);
+      }}
+    />
+  );
+}
+```
+
+## Props Interface
+```typescript
+interface FieldInputProps {
+  label: string;
+  value: string;
+  confidence: number;
+  fieldType?: 'text' | 'rfc' | 'date' | 'amount';
+  userVerified?: boolean;
+  readOnly?: boolean;
+  isSelected?: boolean;
+  onChange: (value: string, userVerified: boolean) => void;
+  onSelect?: () => void;
+}
+```
+
+## Validation Rules
+
+| Field Type | Validation Rule | Error Message (Spanish) |
+|------------|-----------------|------------------------|
+| RFC | 12-13 alphanumeric chars | "RFC debe tener 12 o 13 caracteres alfanuméricos" |
+| Date | YYYY-MM-DD or DD/MM/YYYY | "Formato de fecha inválido" |
+| Amount | Numbers with up to 2 decimals | "Monto inválido" |
+| Text | None | - |

--- a/log_learn/T019.1_FieldInput_LearnLog.md
+++ b/log_learn/T019.1_FieldInput_LearnLog.md
@@ -1,0 +1,203 @@
+# T019.1 Learning Log: Field Input Component
+
+## Date: 2025-12-18
+
+## Key Learnings
+
+### 1. Inline Edit Pattern in React
+
+**Pattern**: Toggle between display and edit modes:
+```typescript
+const [isEditing, setIsEditing] = useState(false);
+const [editValue, setEditValue] = useState(value);
+const inputRef = useRef<HTMLInputElement>(null);
+
+// Auto-focus when entering edit mode
+useEffect(() => {
+  if (isEditing && inputRef.current) {
+    inputRef.current.focus();
+    inputRef.current.select();
+  }
+}, [isEditing]);
+
+return isEditing ? (
+  <input ref={inputRef} value={editValue} onChange={...} />
+) : (
+  <div onClick={startEditing}>{value}</div>
+);
+```
+
+**Benefits**:
+- Clean separation of display and edit states
+- Auto-focus improves UX
+- Select all text for easy replacement
+
+### 2. Keyboard Event Handling
+
+**Pattern**: Handle Enter for save, Escape for cancel:
+```typescript
+const handleKeyDown = useCallback(
+  (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      saveValue();
+    } else if (e.key === 'Escape') {
+      cancelEdit();
+    }
+  },
+  [saveValue, cancelEdit]
+);
+```
+
+**Note**: Use `e.key` instead of `e.keyCode` (deprecated).
+
+### 3. Blur Event with Delay
+
+**Pattern**: Delay blur handling to allow button clicks:
+```typescript
+const handleBlur = useCallback(() => {
+  setTimeout(() => {
+    if (isEditing) {
+      saveValue();
+    }
+  }, 100);
+}, [isEditing, saveValue]);
+```
+
+**Why?**: Without delay, clicking a save button would trigger blur before the click event. The delay allows the button click to register first.
+
+### 4. Validation Function Design
+
+**Pattern**: Return null for valid, error message for invalid:
+```typescript
+function validateValue(value: string, fieldType: FieldType): string | null {
+  if (!value.trim()) return null; // Empty allowed
+
+  switch (fieldType) {
+    case 'rfc':
+      return validateRfc(value) ? null : 'Error message';
+    case 'date':
+      return validateDate(value) ? null : 'Error message';
+    default:
+      return null;
+  }
+}
+```
+
+**Benefits**:
+- Simple truthy check: `if (error) { ... }`
+- Error message ready for display
+- null signals valid state
+
+### 5. RFC Validation (Mexican Tax ID)
+
+**Pattern**: RFC can be 12 or 13 characters:
+```typescript
+function validateRfc(value: string): boolean {
+  // 12 chars for companies, 13 for individuals
+  const rfcRegex = /^[A-Za-z0-9]{12,13}$/;
+  return rfcRegex.test(value.trim());
+}
+```
+
+**Note**: A full RFC validation would check:
+- First 3-4 letters (initials)
+- 6 digits (birth/incorporation date)
+- 3 characters (homoclave)
+But for MVP, length check is sufficient.
+
+### 6. Mexican Date Format Support
+
+**Pattern**: Accept both ISO and local formats:
+```typescript
+function validateDate(value: string): boolean {
+  const isoRegex = /^\d{4}-\d{2}-\d{2}$/;
+  const mxRegex = /^\d{2}\/\d{2}\/\d{4}$/;
+
+  if (isoRegex.test(value)) {
+    return !isNaN(new Date(value).getTime());
+  }
+
+  if (mxRegex.test(value)) {
+    const [day, month, year] = value.split('/').map(Number);
+    const date = new Date(year, month - 1, day);
+    return !isNaN(date.getTime()) && date.getDate() === day;
+  }
+
+  return false;
+}
+```
+
+**Why check `date.getDate() === day`?**: JavaScript's Date auto-corrects invalid dates (Feb 31 → Mar 3). This check ensures the day wasn't auto-corrected.
+
+### 7. Amount Validation
+
+**Pattern**: Accept various number formats:
+```typescript
+function validateAmount(value: string): boolean {
+  const cleanValue = value.replace(/,/g, '');
+  const amountRegex = /^-?\d+(\.\d{0,2})?$/;
+  return amountRegex.test(cleanValue);
+}
+```
+
+**Features**:
+- Remove commas (thousand separators)
+- Allow negative numbers
+- Allow up to 2 decimal places
+
+### 8. Conditional Classes with Join
+
+**Pattern**: Build class strings dynamically:
+```typescript
+const containerClasses = [
+  'border rounded p-2 transition-all duration-150',
+  'hover:bg-gray-50 hover:border-gray-300',
+  isSelected ? 'ring-2 ring-blue-500 border-blue-500' : 'border-gray-200',
+  readOnly ? 'cursor-default' : 'cursor-pointer',
+].join(' ');
+```
+
+**Benefits**:
+- Clear what each condition adds
+- Easy to read and modify
+- No string concatenation bugs
+
+### 9. Click Event Propagation
+
+**Pattern**: Stop propagation for nested clickable elements:
+```typescript
+<div onClick={handleContainerClick}>
+  <div onClick={(e) => {
+    e.stopPropagation();
+    startEditing();
+  }}>
+    {value}
+  </div>
+</div>
+```
+
+**Why?**: Without `stopPropagation`, clicking the value would also trigger container click (double handling).
+
+## Best Practices Applied
+
+1. **Controlled Component**: Value managed by parent via props
+2. **Single Responsibility**: One component for one field
+3. **Reusable**: Works for any field type with validation
+4. **Accessible**: Input receives focus automatically
+5. **Localized**: Spanish error messages and labels
+6. **Testable**: All states and interactions tested
+
+## Design Decisions
+
+1. **Why delay on blur?**: Allow button clicks to register before blur
+2. **Why validate on save, not on change?**: Smoother UX during typing
+3. **Why separate fieldType prop?**: Explicit validation without inferring from label
+4. **Why userVerified in onChange?**: Let parent track verification state
+
+## Potential Improvements
+
+1. Add visual feedback for validation (icon next to input)
+2. Support autocomplete for vendor names
+3. Add undo/redo for edits
+4. Support date picker for date fields
+5. Format amounts with thousand separators on display

--- a/log_tests/T019.1_FieldInput_TestLog.md
+++ b/log_tests/T019.1_FieldInput_TestLog.md
@@ -1,0 +1,137 @@
+# T019.1 Test Log: Field Input Component
+
+## Date: 2025-12-18
+
+## Test File
+`desktop-app/tests/renderer/components/FieldInput.test.tsx`
+
+## Test Summary
+- **Total Tests**: 40
+- **Passed**: 40
+- **Skipped**: 0
+- **Failed**: 0
+
+## Test Categories
+
+### Component Structure Tests (3 tests)
+| Test | Status |
+|------|--------|
+| should export FieldInput component | PASS |
+| should render without crashing | PASS |
+| should render field container | PASS |
+
+### Display Field Information Tests (4 tests)
+| Test | Status |
+|------|--------|
+| should display field label | PASS |
+| should display field value | PASS |
+| should display confidence indicator | PASS |
+| should display empty value placeholder | PASS |
+
+### User Verified Badge Tests (3 tests)
+| Test | Status |
+|------|--------|
+| should not show verified badge by default | PASS |
+| should show verified badge when userVerified is true | PASS |
+| should display checkmark in verified badge | PASS |
+
+### Inline Editing Tests (7 tests)
+| Test | Status |
+|------|--------|
+| should show edit button on hover | PASS |
+| should enter edit mode on click | PASS |
+| should show input field in edit mode | PASS |
+| should focus input when entering edit mode | PASS |
+| should save value on Enter key | PASS |
+| should cancel edit on Escape key | PASS |
+| should save value on blur | PASS |
+
+### Mark as User Verified Tests (2 tests)
+| Test | Status |
+|------|--------|
+| should pass userVerified=true when value is changed | PASS |
+| should not call onChange if value unchanged | PASS |
+
+### RFC Validation Tests (3 tests)
+| Test | Status |
+|------|--------|
+| should validate RFC format (12 or 13 chars) | PASS |
+| should accept valid 12-char RFC | PASS |
+| should accept valid 13-char RFC | PASS |
+
+### Date Validation Tests (3 tests)
+| Test | Status |
+|------|--------|
+| should validate date format | PASS |
+| should accept valid ISO date | PASS |
+| should accept DD/MM/YYYY format | PASS |
+
+### Amount Validation Tests (4 tests)
+| Test | Status |
+|------|--------|
+| should validate amount format | PASS |
+| should accept valid decimal amount | PASS |
+| should accept amount with comma separator | PASS |
+| should accept negative amounts | PASS |
+
+### Text Field Tests (2 tests)
+| Test | Status |
+|------|--------|
+| should accept any text for text field type | PASS |
+| should default to text type if fieldType not specified | PASS |
+
+### Tailwind Styling Tests (5 tests)
+| Test | Status |
+|------|--------|
+| should have border styling | PASS |
+| should have rounded corners | PASS |
+| should have padding | PASS |
+| should have hover state | PASS |
+| should style validation error in red | PASS |
+
+### Read-only Mode Tests (2 tests)
+| Test | Status |
+|------|--------|
+| should not allow editing when readOnly is true | PASS |
+| should not show edit button when readOnly | PASS |
+
+### Field Selection Tests (2 tests)
+| Test | Status |
+|------|--------|
+| should call onSelect when field is clicked | PASS |
+| should highlight when selected | PASS |
+
+## Test Mocks
+```typescript
+// Mock ConfidenceIndicator
+jest.mock('../../../src/renderer/components/ConfidenceIndicator', () => ({
+  ConfidenceIndicator: ({ confidence }: { confidence: number }) => (
+    <div data-testid="confidence-indicator" data-confidence={confidence}>
+      Confidence: {confidence}%
+    </div>
+  ),
+}));
+```
+
+## Test Commands
+```bash
+# Run FieldInput tests only
+cd desktop-app
+npm test -- tests/renderer/components/FieldInput.test.tsx -v
+
+# Run all component tests
+npm test -- tests/renderer/components/ -v
+```
+
+## Total Desktop App Tests
+- T010.1: 28 tests (StatusBar)
+- T010.2: 24 tests (useServiceStatus hook)
+- T015.1: 35 tests (AI service client)
+- T015.2: 32 tests (FileUpload)
+- T016.1: 34 tests (PDFViewer)
+- T016.2: 38 tests (BoundingBoxOverlay)
+- T017.1: 29 tests (ProcessingPage)
+- T017.2: 42 tests (useInvoice hook)
+- T018.1: 43 tests (ConfidenceIndicator)
+- T019.1: 40 tests (FieldInput)
+- **Total: 345 tests**

--- a/specs/001-windows-native-ai/tasks.md
+++ b/specs/001-windows-native-ai/tasks.md
@@ -1086,13 +1086,13 @@
 
 ### T019 - Invoice Form Component
 
-- [ ] **T019.1** Create field input component
-  - [ ] T019.1.1 [P] Write test for field input
-  - [ ] T019.1.2 Create `FieldInput.tsx` component
-  - [ ] T019.1.3 Display field label, value, confidence
-  - [ ] T019.1.4 Enable inline editing on click
-  - [ ] T019.1.5 Mark field as "user_verified" after edit
-  - [ ] T019.1.6 Validate input format (RFC, date, amounts)
+- [x] **T019.1** Create field input component ✅ 2025-12-18
+  - [x] T019.1.1 [P] Write test for field input
+  - [x] T019.1.2 Create `FieldInput.tsx` component
+  - [x] T019.1.3 Display field label, value, confidence
+  - [x] T019.1.4 Enable inline editing on click
+  - [x] T019.1.5 Mark field as "user_verified" after edit
+  - [x] T019.1.6 Validate input format (RFC, date, amounts)
 
 - [ ] **T019.2** Create invoice form
   - [ ] T019.2.1 [P] Write test for form rendering


### PR DESCRIPTION
- Create FieldInput.tsx with label, value, confidence display
- Add inline editing on click with Enter/Escape keyboard support
- Implement validation for RFC (12-13 chars), date (ISO/MX), amount
- Mark fields as user_verified after edit
- Add read-only mode and selection highlighting
- Show verified badge with checkmark
- 40 tests passing