### PR TITLE
feat(T019.3): implement LineItemsTable with editing and auto-calculation

### DIFF
--- a/desktop-app/src/renderer/components/LineItemsTable.tsx
+++ b/desktop-app/src/renderer/components/LineItemsTable.tsx
@@ -1,0 +1,405 @@
+/**
+ * T019.3 - LineItemsTable Component
+ *
+ * Editable table for invoice line items that:
+ * - Displays line items with description, quantity, unit price, amount
+ * - Supports row editing with inline inputs
+ * - Auto-calculates row amounts (quantity * unit price)
+ * - Validates totals match expected subtotal
+ *
+ * Uses Tailwind CSS for styling.
+ */
+
+import React, { useState, useCallback, useMemo } from 'react';
+import { ConfidenceIndicator } from './ConfidenceIndicator';
+import type { LineItemExtraction } from '../types';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Props for LineItemsTable component
+ */
+export interface LineItemsTableProps {
+  /** Line items to display */
+  items: LineItemExtraction[];
+  /** Callback when items change: (updatedItems) */
+  onChange: (items: LineItemExtraction[]) => void;
+  /** Expected subtotal from header for validation */
+  expectedSubtotal?: number;
+  /** Whether the table is read-only */
+  readOnly?: boolean;
+}
+
+/**
+ * Editable line item state
+ */
+interface EditingItem {
+  description: string;
+  quantity: string;
+  unitPrice: string;
+  amount: string;
+}
+
+// =============================================================================
+// Utility Functions
+// =============================================================================
+
+/**
+ * Format number as currency (Mexican Peso style)
+ */
+function formatCurrency(value: number): string {
+  return '$' + value.toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+/**
+ * Parse currency/number string to number
+ */
+function parseNumber(value: string): number {
+  const cleaned = value.replace(/[,$]/g, '');
+  const parsed = parseFloat(cleaned);
+  return isNaN(parsed) ? 0 : parsed;
+}
+
+/**
+ * Calculate amount from quantity and unit price
+ */
+function calculateAmount(quantity: number, unitPrice: number): number {
+  return Math.round(quantity * unitPrice * 100) / 100;
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * LineItemsTable component for editing invoice line items
+ *
+ * @example
+ * ```tsx
+ * <LineItemsTable
+ *   items={extraction.lineItems}
+ *   onChange={(updatedItems) => setLineItems(updatedItems)}
+ *   expectedSubtotal={parseFloat(extraction.subtotal.value)}
+ * />
+ * ```
+ */
+export function LineItemsTable({
+  items,
+  onChange,
+  expectedSubtotal,
+  readOnly = false,
+}: LineItemsTableProps): JSX.Element {
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [editingItem, setEditingItem] = useState<EditingItem | null>(null);
+
+  /**
+   * Calculate total of all line items
+   */
+  const calculatedTotal = useMemo(() => {
+    return items.reduce((sum, item) => sum + item.amount, 0);
+  }, [items]);
+
+  /**
+   * Check if totals match
+   */
+  const totalsMatch = useMemo(() => {
+    if (expectedSubtotal === undefined) return null;
+    return Math.abs(calculatedTotal - expectedSubtotal) < 0.01;
+  }, [calculatedTotal, expectedSubtotal]);
+
+  /**
+   * Calculate difference between totals
+   */
+  const totalsDifference = useMemo(() => {
+    if (expectedSubtotal === undefined) return 0;
+    return Math.abs(calculatedTotal - expectedSubtotal);
+  }, [calculatedTotal, expectedSubtotal]);
+
+  /**
+   * Start editing a row
+   */
+  const startEditing = useCallback(
+    (index: number) => {
+      if (readOnly) return;
+
+      const item = items[index];
+      setEditingIndex(index);
+      setEditingItem({
+        description: item.description,
+        quantity: item.quantity.toString(),
+        unitPrice: item.unitPrice.toString(),
+        amount: item.amount.toString(),
+      });
+    },
+    [items, readOnly]
+  );
+
+  /**
+   * Cancel editing
+   */
+  const cancelEditing = useCallback(() => {
+    setEditingIndex(null);
+    setEditingItem(null);
+  }, []);
+
+  /**
+   * Save edited row
+   */
+  const saveEditing = useCallback(() => {
+    if (editingIndex === null || editingItem === null) return;
+
+    const updatedItems = [...items];
+    updatedItems[editingIndex] = {
+      ...updatedItems[editingIndex],
+      description: editingItem.description,
+      quantity: parseNumber(editingItem.quantity),
+      unitPrice: parseNumber(editingItem.unitPrice),
+      amount: parseNumber(editingItem.amount),
+    };
+
+    onChange(updatedItems);
+    setEditingIndex(null);
+    setEditingItem(null);
+  }, [editingIndex, editingItem, items, onChange]);
+
+  /**
+   * Handle input change with auto-calculation
+   */
+  const handleInputChange = useCallback(
+    (field: keyof EditingItem, value: string) => {
+      if (!editingItem) return;
+
+      const newItem = { ...editingItem, [field]: value };
+
+      // Auto-calculate amount when quantity or unitPrice changes
+      if (field === 'quantity' || field === 'unitPrice') {
+        const qty = parseNumber(newItem.quantity);
+        const price = parseNumber(newItem.unitPrice);
+        newItem.amount = calculateAmount(qty, price).toString();
+      }
+
+      setEditingItem(newItem);
+    },
+    [editingItem]
+  );
+
+  /**
+   * Handle key press in edit mode
+   */
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        saveEditing();
+      } else if (e.key === 'Escape') {
+        cancelEditing();
+      }
+    },
+    [saveEditing, cancelEditing]
+  );
+
+  /**
+   * Render a display row
+   */
+  const renderDisplayRow = (item: LineItemExtraction, index: number) => (
+    <tr
+      key={index}
+      data-testid={`line-item-row-${index}`}
+      className={`
+        ${index % 2 === 1 ? 'bg-gray-50' : 'bg-white'}
+        hover:bg-blue-50 cursor-pointer transition-colors
+      `}
+      onClick={() => startEditing(index)}
+    >
+      <td className="px-3 py-2 text-sm text-gray-900">{item.description}</td>
+      <td className="px-3 py-2 text-sm text-gray-900 text-right">{item.quantity}</td>
+      <td className="px-3 py-2 text-sm text-gray-900 text-right">
+        {formatCurrency(item.unitPrice)}
+      </td>
+      <td className="px-3 py-2 text-sm text-gray-900 text-right font-medium">
+        {formatCurrency(item.amount)}
+      </td>
+      <td className="px-3 py-2 text-center">
+        <ConfidenceIndicator confidence={item.confidence} size="sm" />
+      </td>
+    </tr>
+  );
+
+  /**
+   * Render an editing row
+   */
+  const renderEditRow = (index: number) => {
+    if (!editingItem) return null;
+
+    return (
+      <tr
+        key={index}
+        data-testid={`edit-row-${index}`}
+        className="bg-blue-50"
+      >
+        <td className="px-2 py-1">
+          <input
+            type="text"
+            value={editingItem.description}
+            onChange={(e) => handleInputChange('description', e.target.value)}
+            onKeyDown={handleKeyDown}
+            className="w-full px-2 py-1 text-sm border rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </td>
+        <td className="px-2 py-1">
+          <input
+            type="text"
+            value={editingItem.quantity}
+            onChange={(e) => handleInputChange('quantity', e.target.value)}
+            onKeyDown={handleKeyDown}
+            className="w-20 px-2 py-1 text-sm text-right border rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </td>
+        <td className="px-2 py-1">
+          <input
+            type="text"
+            value={editingItem.unitPrice}
+            onChange={(e) => handleInputChange('unitPrice', e.target.value)}
+            onKeyDown={handleKeyDown}
+            className="w-24 px-2 py-1 text-sm text-right border rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </td>
+        <td className="px-2 py-1">
+          <input
+            type="text"
+            value={editingItem.amount}
+            readOnly
+            className="w-24 px-2 py-1 text-sm text-right border rounded bg-gray-100"
+          />
+        </td>
+        <td className="px-2 py-1 text-center">
+          <div className="flex gap-1 justify-center">
+            <button
+              data-testid="save-button"
+              onClick={saveEditing}
+              className="px-2 py-1 text-xs bg-green-500 text-white rounded hover:bg-green-600"
+            >
+              ✓
+            </button>
+            <button
+              data-testid="cancel-button"
+              onClick={cancelEditing}
+              className="px-2 py-1 text-xs bg-gray-500 text-white rounded hover:bg-gray-600"
+            >
+              ✕
+            </button>
+          </div>
+        </td>
+      </tr>
+    );
+  };
+
+  return (
+    <div data-testid="line-items-table" className="mt-4">
+      {/* Section Title */}
+      <h3 className="text-sm font-medium text-gray-700 mb-3">Conceptos</h3>
+
+      {items.length === 0 ? (
+        <p className="text-gray-500 text-sm italic">No hay conceptos</p>
+      ) : (
+        <>
+          {/* Table */}
+          <div className="overflow-x-auto border rounded-lg">
+            <table className="w-full">
+              <thead className="bg-gray-100">
+                <tr>
+                  <th className="px-3 py-2 text-left text-xs font-medium text-gray-600 uppercase">
+                    Descripción
+                  </th>
+                  <th className="px-3 py-2 text-right text-xs font-medium text-gray-600 uppercase">
+                    Cantidad
+                  </th>
+                  <th className="px-3 py-2 text-right text-xs font-medium text-gray-600 uppercase">
+                    Precio Unitario
+                  </th>
+                  <th className="px-3 py-2 text-right text-xs font-medium text-gray-600 uppercase">
+                    Importe
+                  </th>
+                  <th className="px-3 py-2 text-center text-xs font-medium text-gray-600 uppercase">
+                    Conf.
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map((item, index) =>
+                  editingIndex === index
+                    ? renderEditRow(index)
+                    : renderDisplayRow(item, index)
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Totals Section */}
+          <div className="mt-3 flex justify-end">
+            <div className="text-sm space-y-1">
+              {/* Calculated Total */}
+              <div className="flex justify-between gap-8">
+                <span className="text-gray-600">Total Calculado:</span>
+                <span
+                  data-testid="calculated-total"
+                  className="font-medium text-gray-900"
+                >
+                  {formatCurrency(calculatedTotal)}
+                </span>
+              </div>
+
+              {/* Expected Total (if provided) */}
+              {expectedSubtotal !== undefined && (
+                <>
+                  <div className="flex justify-between gap-8">
+                    <span className="text-gray-600">Subtotal Esperado:</span>
+                    <span
+                      data-testid="expected-total"
+                      className="font-medium text-gray-900"
+                    >
+                      {formatCurrency(expectedSubtotal)}
+                    </span>
+                  </div>
+
+                  {/* Match/Mismatch Indicator */}
+                  {totalsMatch ? (
+                    <div
+                      data-testid="totals-match"
+                      className="flex items-center justify-end gap-2 text-green-600"
+                    >
+                      <span>✓</span>
+                      <span>Los totales coinciden</span>
+                    </div>
+                  ) : (
+                    <div className="text-red-600">
+                      <div
+                        data-testid="totals-mismatch"
+                        className="flex items-center justify-end gap-2"
+                      >
+                        <span>✕</span>
+                        <span>Los totales no coinciden</span>
+                      </div>
+                      <div className="flex justify-between gap-8 mt-1">
+                        <span>Diferencia:</span>
+                        <span data-testid="totals-difference">
+                          {formatCurrency(totalsDifference)}
+                        </span>
+                      </div>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default LineItemsTable;

--- a/desktop-app/tests/renderer/components/LineItemsTable.test.tsx
+++ b/desktop-app/tests/renderer/components/LineItemsTable.test.tsx
@@ -1,0 +1,610 @@
+/**
+ * T019.3 - LineItemsTable Component Tests
+ *
+ * Tests for the line items table component that:
+ * - Displays editable table rows
+ * - Supports row editing
+ * - Auto-calculates row amounts
+ * - Validates totals match
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { LineItemExtraction } from '../../../src/renderer/types';
+
+// Will be created in T019.3.2
+let LineItemsTable: typeof import('../../../src/renderer/components/LineItemsTable').LineItemsTable;
+
+// Mock ConfidenceIndicator
+jest.mock('../../../src/renderer/components/ConfidenceIndicator', () => ({
+  ConfidenceIndicator: ({ confidence }: { confidence: number }) => (
+    <span data-testid="confidence-indicator" data-confidence={confidence}>
+      {confidence}%
+    </span>
+  ),
+}));
+
+/**
+ * Create mock line items
+ */
+function createMockLineItems(): LineItemExtraction[] {
+  return [
+    {
+      description: 'Producto A',
+      quantity: 2,
+      unitPrice: 100.0,
+      amount: 200.0,
+      confidence: 95,
+    },
+    {
+      description: 'Servicio B',
+      quantity: 1,
+      unitPrice: 500.0,
+      amount: 500.0,
+      confidence: 88,
+    },
+    {
+      description: 'Material C',
+      quantity: 5,
+      unitPrice: 60.0,
+      amount: 300.0,
+      confidence: 92,
+    },
+  ];
+}
+
+describe('T019.3 - LineItemsTable Component', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module = await import('../../../src/renderer/components/LineItemsTable');
+    LineItemsTable = module.LineItemsTable;
+  });
+
+  // ==========================================================================
+  // T019.3.1 - Component Structure Tests
+  // ==========================================================================
+
+  describe('T019.3.1 - Component Structure', () => {
+    it('should export LineItemsTable component', async () => {
+      const module = await import('../../../src/renderer/components/LineItemsTable');
+      expect(module.LineItemsTable).toBeDefined();
+      expect(typeof module.LineItemsTable).toBe('function');
+    });
+
+    it('should render without crashing', () => {
+      expect(() => {
+        render(
+          <LineItemsTable
+            items={createMockLineItems()}
+            onChange={() => {}}
+          />
+        );
+      }).not.toThrow();
+    });
+
+    it('should render table container', () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+        />
+      );
+      expect(screen.getByTestId('line-items-table')).toBeInTheDocument();
+    });
+
+    it('should render table element', () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+        />
+      );
+      expect(screen.getByRole('table')).toBeInTheDocument();
+    });
+
+    it('should render section title', () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+        />
+      );
+      expect(screen.getByText('Conceptos')).toBeInTheDocument();
+    });
+  });
+
+  // ==========================================================================
+  // T019.3.2 - Table Headers Tests
+  // ==========================================================================
+
+  describe('T019.3.2 - Table Headers', () => {
+    it('should render description header', () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+        />
+      );
+      expect(screen.getByText('Descripción')).toBeInTheDocument();
+    });
+
+    it('should render quantity header', () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+        />
+      );
+      expect(screen.getByText('Cantidad')).toBeInTheDocument();
+    });
+
+    it('should render unit price header', () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+        />
+      );
+      expect(screen.getByText('Precio Unitario')).toBeInTheDocument();
+    });
+
+    it('should render amount header', () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+        />
+      );
+      expect(screen.getByText('Importe')).toBeInTheDocument();
+    });
+
+    it('should render confidence header', () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+        />
+      );
+      expect(screen.getByText('Conf.')).toBeInTheDocument();
+    });
+  });
+
+  // ==========================================================================
+  // T019.3.3 - Display Line Items Tests
+  // ==========================================================================
+
+  describe('T019.3.3 - Display Line Items', () => {
+    it('should render correct number of rows', () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+        />
+      );
+      const rows = screen.getAllByTestId(/^line-item-row-/);
+      expect(rows).toHaveLength(3);
+    });
+
+    it('should display item descriptions', () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+        />
+      );
+      expect(screen.getByText('Producto A')).toBeInTheDocument();
+      expect(screen.getByText('Servicio B')).toBeInTheDocument();
+      expect(screen.getByText('Material C')).toBeInTheDocument();
+    });
+
+    it('should display item quantities', () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+        />
+      );
+      expect(screen.getByText('2')).toBeInTheDocument();
+      expect(screen.getByText('1')).toBeInTheDocument();
+      expect(screen.getByText('5')).toBeInTheDocument();
+    });
+
+    it('should display unit prices formatted', () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+        />
+      );
+      expect(screen.getByText('$100.00')).toBeInTheDocument();
+      // $500.00 appears twice (unit price and amount for item 2)
+      expect(screen.getAllByText('$500.00').length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText('$60.00')).toBeInTheDocument();
+    });
+
+    it('should display amounts formatted', () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+        />
+      );
+      expect(screen.getByText('$200.00')).toBeInTheDocument();
+      // $500.00 appears twice (unit price and amount for item 2)
+      expect(screen.getAllByText('$500.00').length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText('$300.00')).toBeInTheDocument();
+    });
+
+    it('should display confidence indicators', () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+        />
+      );
+      const indicators = screen.getAllByTestId('confidence-indicator');
+      expect(indicators).toHaveLength(3);
+    });
+
+    it('should handle empty items array', () => {
+      render(
+        <LineItemsTable
+          items={[]}
+          onChange={() => {}}
+        />
+      );
+      expect(screen.getByText('No hay conceptos')).toBeInTheDocument();
+    });
+  });
+
+  // ==========================================================================
+  // T019.3.4 - Row Editing Tests
+  // ==========================================================================
+
+  describe('T019.3.4 - Row Editing', () => {
+    it('should enter edit mode when row is clicked', async () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+        />
+      );
+
+      const row = screen.getByTestId('line-item-row-0');
+      fireEvent.click(row);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('edit-row-0')).toBeInTheDocument();
+      });
+    });
+
+    it('should show input fields in edit mode', async () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+        />
+      );
+
+      const row = screen.getByTestId('line-item-row-0');
+      fireEvent.click(row);
+
+      await waitFor(() => {
+        const editRow = screen.getByTestId('edit-row-0');
+        expect(within(editRow).getByDisplayValue('Producto A')).toBeInTheDocument();
+        expect(within(editRow).getByDisplayValue('2')).toBeInTheDocument();
+        expect(within(editRow).getByDisplayValue('100')).toBeInTheDocument();
+      });
+    });
+
+    it('should save changes on Enter key', async () => {
+      const handleChange = jest.fn();
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={handleChange}
+        />
+      );
+
+      const row = screen.getByTestId('line-item-row-0');
+      fireEvent.click(row);
+
+      await waitFor(() => {
+        const descInput = screen.getByDisplayValue('Producto A');
+        fireEvent.change(descInput, { target: { value: 'Producto Modificado' } });
+        fireEvent.keyDown(descInput, { key: 'Enter' });
+      });
+
+      expect(handleChange).toHaveBeenCalled();
+    });
+
+    it('should cancel edit on Escape key', async () => {
+      const handleChange = jest.fn();
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={handleChange}
+        />
+      );
+
+      const row = screen.getByTestId('line-item-row-0');
+      fireEvent.click(row);
+
+      await waitFor(() => {
+        const descInput = screen.getByDisplayValue('Producto A');
+        fireEvent.change(descInput, { target: { value: 'Producto Modificado' } });
+        fireEvent.keyDown(descInput, { key: 'Escape' });
+      });
+
+      expect(handleChange).not.toHaveBeenCalled();
+      expect(screen.getByText('Producto A')).toBeInTheDocument();
+    });
+
+    it('should have save and cancel buttons in edit mode', async () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+        />
+      );
+
+      const row = screen.getByTestId('line-item-row-0');
+      fireEvent.click(row);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('save-button')).toBeInTheDocument();
+        expect(screen.getByTestId('cancel-button')).toBeInTheDocument();
+      });
+    });
+  });
+
+  // ==========================================================================
+  // T019.3.5 - Auto-calculate Row Amounts Tests
+  // ==========================================================================
+
+  describe('T019.3.5 - Auto-calculate Row Amounts', () => {
+    it('should auto-calculate amount when quantity changes', async () => {
+      const handleChange = jest.fn();
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={handleChange}
+        />
+      );
+
+      const row = screen.getByTestId('line-item-row-0');
+      fireEvent.click(row);
+
+      await waitFor(() => {
+        const qtyInput = screen.getByDisplayValue('2');
+        fireEvent.change(qtyInput, { target: { value: '3' } });
+      });
+
+      // Amount should update to 3 * 100 = 300
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('300')).toBeInTheDocument();
+      });
+    });
+
+    it('should auto-calculate amount when unit price changes', async () => {
+      const handleChange = jest.fn();
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={handleChange}
+        />
+      );
+
+      const row = screen.getByTestId('line-item-row-0');
+      fireEvent.click(row);
+
+      await waitFor(() => {
+        const priceInput = screen.getByDisplayValue('100');
+        fireEvent.change(priceInput, { target: { value: '150' } });
+      });
+
+      // Amount should update to 2 * 150 = 300
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('300')).toBeInTheDocument();
+      });
+    });
+
+    it('should handle decimal quantities', async () => {
+      render(
+        <LineItemsTable
+          items={[{
+            description: 'Item',
+            quantity: 1.5,
+            unitPrice: 100,
+            amount: 150,
+            confidence: 90,
+          }]}
+          onChange={() => {}}
+        />
+      );
+
+      const row = screen.getByTestId('line-item-row-0');
+      fireEvent.click(row);
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('1.5')).toBeInTheDocument();
+      });
+    });
+  });
+
+  // ==========================================================================
+  // T019.3.6 - Totals Validation Tests
+  // ==========================================================================
+
+  describe('T019.3.6 - Totals Validation', () => {
+    it('should display calculated total', () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+        />
+      );
+      // Total: 200 + 500 + 300 = 1000
+      expect(screen.getByTestId('calculated-total')).toHaveTextContent('$1,000.00');
+    });
+
+    it('should show expected total when provided', () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+          expectedSubtotal={1000}
+        />
+      );
+      expect(screen.getByTestId('expected-total')).toHaveTextContent('$1,000.00');
+    });
+
+    it('should show match indicator when totals match', () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+          expectedSubtotal={1000}
+        />
+      );
+      expect(screen.getByTestId('totals-match')).toBeInTheDocument();
+    });
+
+    it('should show mismatch indicator when totals differ', () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+          expectedSubtotal={999}
+        />
+      );
+      expect(screen.getByTestId('totals-mismatch')).toBeInTheDocument();
+    });
+
+    it('should show difference amount when totals mismatch', () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+          expectedSubtotal={950}
+        />
+      );
+      expect(screen.getByTestId('totals-difference')).toHaveTextContent('$50.00');
+    });
+  });
+
+  // ==========================================================================
+  // Tailwind Styling Tests
+  // ==========================================================================
+
+  describe('Tailwind Styling', () => {
+    it('should have table with full width', () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+        />
+      );
+      const table = screen.getByRole('table');
+      expect(table).toHaveClass('w-full');
+    });
+
+    it('should have striped rows', () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+        />
+      );
+      const rows = screen.getAllByTestId(/^line-item-row-/);
+      // Check that odd rows have different background
+      expect(rows[1].className).toMatch(/bg-gray-50/);
+    });
+
+    it('should have hover state on rows', () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+        />
+      );
+      const rows = screen.getAllByTestId(/^line-item-row-/);
+      expect(rows[0].className).toMatch(/hover:/);
+    });
+
+    it('should align numbers to right', () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+        />
+      );
+      const amountCell = screen.getByText('$200.00').closest('td');
+      expect(amountCell).toHaveClass('text-right');
+    });
+  });
+
+  // ==========================================================================
+  // Read-only Mode Tests
+  // ==========================================================================
+
+  describe('Read-only Mode', () => {
+    it('should not enter edit mode when readOnly', () => {
+      render(
+        <LineItemsTable
+          items={createMockLineItems()}
+          onChange={() => {}}
+          readOnly
+        />
+      );
+
+      const row = screen.getByTestId('line-item-row-0');
+      fireEvent.click(row);
+
+      expect(screen.queryByTestId('edit-row-0')).not.toBeInTheDocument();
+    });
+  });
+
+  // ==========================================================================
+  // Currency Formatting Tests
+  // ==========================================================================
+
+  describe('Currency Formatting', () => {
+    it('should format large amounts with thousand separators', () => {
+      render(
+        <LineItemsTable
+          items={[{
+            description: 'Item grande',
+            quantity: 1,
+            unitPrice: 10000,
+            amount: 10000,
+            confidence: 90,
+          }]}
+          onChange={() => {}}
+        />
+      );
+      // Both unit price and amount show $10,000.00
+      const formatted = screen.getAllByText('$10,000.00');
+      expect(formatted.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should format amounts with two decimal places', () => {
+      render(
+        <LineItemsTable
+          items={[{
+            description: 'Item',
+            quantity: 1,
+            unitPrice: 99.9,
+            amount: 99.9,
+            confidence: 90,
+          }]}
+          onChange={() => {}}
+        />
+      );
+      // Both unit price and amount show $99.90
+      const formatted = screen.getAllByText('$99.90');
+      expect(formatted.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/log_files/T019.3_LineItemsTable_Log.md
+++ b/log_files/T019.3_LineItemsTable_Log.md
@@ -1,0 +1,89 @@
+# T019.3 Implementation Log: LineItemsTable Component
+
+## Date: 2025-12-18
+
+## Task Description
+Create editable line items table component that displays invoice line items, supports inline row editing, auto-calculates row amounts, and validates totals against expected subtotal.
+
+## Subtasks Completed
+
+### T019.3.1 - Write tests for line items table
+Created comprehensive test suite with 37 tests covering:
+- Component structure and exports
+- Table headers (Descripción, Cantidad, Precio Unitario, Importe, Conf.)
+- Display of line items with formatting
+- Row editing with Enter/Escape handling
+- Auto-calculation of amounts
+- Totals validation with match/mismatch indicators
+- Tailwind styling (striped rows, hover states)
+- Read-only mode
+- Currency formatting
+
+### T019.3.2-6 - Create LineItemsTable component
+Created component with all required functionality:
+- Editable table rows with inline inputs
+- Auto-calculation: amount = quantity × unitPrice
+- Totals comparison with expected subtotal
+- Match/mismatch indicators
+- Currency formatting with thousand separators
+
+## Files Created
+- `desktop-app/src/renderer/components/LineItemsTable.tsx`
+- `desktop-app/tests/renderer/components/LineItemsTable.test.tsx`
+
+## Test Results
+- Total tests: 37
+- Passed: 37
+- Failed: 0
+
+## Component Features
+
+### Props Interface
+```typescript
+interface LineItemsTableProps {
+  items: LineItemExtraction[];
+  onChange: (items: LineItemExtraction[]) => void;
+  expectedSubtotal?: number;
+  readOnly?: boolean;
+}
+```
+
+### Key Features
+1. **Display Mode**: Shows items with description, quantity, unit price, amount, confidence
+2. **Edit Mode**: Click row to enter edit mode with input fields
+3. **Auto-calculation**: Amount updates automatically when quantity or price changes
+4. **Keyboard Support**: Enter to save, Escape to cancel
+5. **Totals Validation**: Compares calculated total with expected subtotal
+6. **Visual Indicators**: Green checkmark when totals match, red X with difference when mismatch
+
+### Table Layout
+```
+┌────────────────┬──────────┬───────────────┬──────────┬───────┐
+│ Descripción    │ Cantidad │ Precio Unit.  │ Importe  │ Conf. │
+├────────────────┼──────────┼───────────────┼──────────┼───────┤
+│ Producto A     │        2 │      $100.00  │  $200.00 │  95%  │
+│ Servicio B     │        1 │      $500.00  │  $500.00 │  88%  │
+│ Material C     │        5 │       $60.00  │  $300.00 │  92%  │
+├────────────────┴──────────┴───────────────┼──────────┼───────┤
+│                         Total Calculado:  │$1,000.00 │       │
+│                        Subtotal Esperado: │$1,000.00 │       │
+│                      ✓ Los totales coinciden        │       │
+└───────────────────────────────────────────┴──────────┴───────┘
+```
+
+## Usage Example
+```tsx
+import { LineItemsTable } from './components/LineItemsTable';
+
+function InvoicePage() {
+  const [items, setItems] = useState<LineItemExtraction[]>(extraction.lineItems);
+
+  return (
+    <LineItemsTable
+      items={items}
+      onChange={setItems}
+      expectedSubtotal={parseFloat(extraction.subtotal.value)}
+    />
+  );
+}
+```

--- a/log_learn/T019.3_LineItemsTable_LearnLog.md
+++ b/log_learn/T019.3_LineItemsTable_LearnLog.md
@@ -1,0 +1,131 @@
+# T019.3 Learning Log: LineItemsTable Component
+
+## Date: 2025-12-18
+
+## Concepts Learned
+
+### 1. Inline Table Editing Pattern
+Learned how to implement row-level editing in a table:
+- **Display Mode**: Normal table row with formatted values
+- **Edit Mode**: Table row with input fields
+- **State Management**: Track which row is being edited via `editingIndex`
+- **Editing Values**: Separate state object (`editingItem`) for in-progress edits
+
+```typescript
+const [editingIndex, setEditingIndex] = useState<number | null>(null);
+const [editingItem, setEditingItem] = useState<EditingItem | null>(null);
+
+const startEditing = (index: number) => {
+  setEditingIndex(index);
+  setEditingItem({
+    description: items[index].description,
+    quantity: items[index].quantity.toString(),
+    // ... convert numbers to strings for inputs
+  });
+};
+```
+
+### 2. Auto-calculation in Forms
+Implemented real-time calculation when input values change:
+
+```typescript
+const handleInputChange = (field: keyof EditingItem, value: string) => {
+  const newItem = { ...editingItem, [field]: value };
+
+  // Auto-calculate amount when quantity or unitPrice changes
+  if (field === 'quantity' || field === 'unitPrice') {
+    const qty = parseNumber(newItem.quantity);
+    const price = parseNumber(newItem.unitPrice);
+    newItem.amount = calculateAmount(qty, price).toString();
+  }
+
+  setEditingItem(newItem);
+};
+```
+
+Key insight: Make the amount field read-only in edit mode since it's calculated.
+
+### 3. Currency Formatting with toLocaleString
+Used built-in JavaScript formatting for currency:
+
+```typescript
+function formatCurrency(value: number): string {
+  return '$' + value.toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+// Result: 1000 → "$1,000.00"
+```
+
+### 4. Floating Point Precision
+Learned to handle floating point calculation issues:
+
+```typescript
+function calculateAmount(quantity: number, unitPrice: number): number {
+  // Round to 2 decimal places to avoid floating point errors
+  return Math.round(quantity * unitPrice * 100) / 100;
+}
+```
+
+### 5. Testing with Duplicate Text
+When the same value appears multiple times in a component (like $500.00 in both unit price and amount columns):
+
+```typescript
+// BAD: Will fail if value appears more than once
+expect(screen.getByText('$500.00')).toBeInTheDocument();
+
+// GOOD: Handle multiple occurrences
+expect(screen.getAllByText('$500.00').length).toBeGreaterThanOrEqual(1);
+```
+
+### 6. Striped Table Rows with Tailwind
+Simple conditional class for zebra striping:
+
+```tsx
+<tr className={index % 2 === 1 ? 'bg-gray-50' : 'bg-white'}>
+```
+
+### 7. Totals Validation Pattern
+Comparing calculated total with expected value:
+
+```typescript
+const totalsMatch = useMemo(() => {
+  if (expectedSubtotal === undefined) return null;
+  // Use small epsilon for floating point comparison
+  return Math.abs(calculatedTotal - expectedSubtotal) < 0.01;
+}, [calculatedTotal, expectedSubtotal]);
+```
+
+## Best Practices Identified
+
+1. **Separate Edit State**: Don't mutate the original data while editing - maintain separate state
+2. **String Inputs for Numbers**: Convert numbers to strings for form inputs, parse back on save
+3. **Read-only Calculated Fields**: Make auto-calculated fields visually distinct and non-editable
+4. **Keyboard Navigation**: Support Enter to save and Escape to cancel
+5. **Visual Feedback**: Use colors/icons to indicate match/mismatch status
+
+## Patterns to Reuse
+
+### Editable Table Row Pattern
+```typescript
+{items.map((item, index) =>
+  editingIndex === index
+    ? renderEditRow(index)
+    : renderDisplayRow(item, index)
+)}
+```
+
+### Currency Input Pattern
+```typescript
+function parseNumber(value: string): number {
+  const cleaned = value.replace(/[,$]/g, '');
+  const parsed = parseFloat(cleaned);
+  return isNaN(parsed) ? 0 : parsed;
+}
+```
+
+## Questions for Future
+- Should we support batch editing of multiple rows?
+- How to handle very long item descriptions (truncation vs wrapping)?
+- Should changes auto-save or require explicit save button?

--- a/log_tests/T019.3_LineItemsTable_TestLog.md
+++ b/log_tests/T019.3_LineItemsTable_TestLog.md
@@ -1,0 +1,123 @@
+# T019.3 Test Log: LineItemsTable Component
+
+## Date: 2025-12-18
+
+## Test File
+`desktop-app/tests/renderer/components/LineItemsTable.test.tsx`
+
+## Test Results Summary
+- **Total Tests**: 37
+- **Passed**: 37
+- **Failed**: 0
+- **Duration**: ~3 seconds
+
+## Test Suites
+
+### T019.3.1 - Component Structure (5 tests)
+| Test | Status | Description |
+|------|--------|-------------|
+| should export LineItemsTable component | ✅ | Verifies module exports |
+| should render without crashing | ✅ | Basic render test |
+| should render table container | ✅ | data-testid="line-items-table" |
+| should render table element | ✅ | role="table" |
+| should render section title | ✅ | "Conceptos" heading |
+
+### T019.3.2 - Table Headers (5 tests)
+| Test | Status | Description |
+|------|--------|-------------|
+| should render description header | ✅ | "Descripción" |
+| should render quantity header | ✅ | "Cantidad" |
+| should render unit price header | ✅ | "Precio Unitario" |
+| should render amount header | ✅ | "Importe" |
+| should render confidence header | ✅ | "Conf." |
+
+### T019.3.3 - Display Line Items (7 tests)
+| Test | Status | Description |
+|------|--------|-------------|
+| should render correct number of rows | ✅ | 3 rows for 3 items |
+| should display item descriptions | ✅ | Producto A, Servicio B, Material C |
+| should display item quantities | ✅ | 2, 1, 5 |
+| should display unit prices formatted | ✅ | $100.00, $500.00, $60.00 |
+| should display amounts formatted | ✅ | $200.00, $500.00, $300.00 |
+| should display confidence indicators | ✅ | 3 indicators rendered |
+| should handle empty items array | ✅ | "No hay conceptos" message |
+
+### T019.3.4 - Row Editing (6 tests)
+| Test | Status | Description |
+|------|--------|-------------|
+| should enter edit mode when row is clicked | ✅ | Shows edit-row-0 |
+| should show input fields in edit mode | ✅ | Inputs with current values |
+| should save changes on Enter key | ✅ | onChange called |
+| should cancel edit on Escape key | ✅ | onChange not called |
+| should have save and cancel buttons | ✅ | Save ✓ and Cancel ✕ buttons |
+
+### T019.3.5 - Auto-calculate Row Amounts (3 tests)
+| Test | Status | Description |
+|------|--------|-------------|
+| should auto-calculate when quantity changes | ✅ | 3 × 100 = 300 |
+| should auto-calculate when unit price changes | ✅ | 2 × 150 = 300 |
+| should handle decimal quantities | ✅ | 1.5 supported |
+
+### T019.3.6 - Totals Validation (5 tests)
+| Test | Status | Description |
+|------|--------|-------------|
+| should display calculated total | ✅ | $1,000.00 |
+| should show expected total when provided | ✅ | From expectedSubtotal prop |
+| should show match indicator when totals match | ✅ | data-testid="totals-match" |
+| should show mismatch indicator when totals differ | ✅ | data-testid="totals-mismatch" |
+| should show difference amount | ✅ | $50.00 difference |
+
+### Tailwind Styling (4 tests)
+| Test | Status | Description |
+|------|--------|-------------|
+| should have table with full width | ✅ | w-full class |
+| should have striped rows | ✅ | bg-gray-50 on odd rows |
+| should have hover state on rows | ✅ | hover: classes |
+| should align numbers to right | ✅ | text-right class |
+
+### Read-only Mode (1 test)
+| Test | Status | Description |
+|------|--------|-------------|
+| should not enter edit mode when readOnly | ✅ | No edit row shown |
+
+### Currency Formatting (2 tests)
+| Test | Status | Description |
+|------|--------|-------------|
+| should format large amounts with separators | ✅ | $10,000.00 |
+| should format with two decimal places | ✅ | $99.90 |
+
+## Key Testing Patterns
+
+### Mock Setup
+```typescript
+jest.mock('../../../src/renderer/components/ConfidenceIndicator', () => ({
+  ConfidenceIndicator: ({ confidence }: { confidence: number }) => (
+    <span data-testid="confidence-indicator" data-confidence={confidence}>
+      {confidence}%
+    </span>
+  ),
+}));
+```
+
+### Test Data Factory
+```typescript
+function createMockLineItems(): LineItemExtraction[] {
+  return [
+    { description: 'Producto A', quantity: 2, unitPrice: 100.0, amount: 200.0, confidence: 95 },
+    { description: 'Servicio B', quantity: 1, unitPrice: 500.0, amount: 500.0, confidence: 88 },
+    { description: 'Material C', quantity: 5, unitPrice: 60.0, amount: 300.0, confidence: 92 },
+  ];
+}
+```
+
+### Handling Duplicate Values
+For cases where the same value appears in multiple columns (like $500.00 appearing as both unit price and amount):
+```typescript
+// Use getAllByText instead of getByText
+expect(screen.getAllByText('$500.00').length).toBeGreaterThanOrEqual(1);
+```
+
+## Test Execution Command
+```bash
+cd desktop-app && npm test -- --testPathPattern="LineItemsTable"
+```

--- a/specs/001-windows-native-ai/tasks.md
+++ b/specs/001-windows-native-ai/tasks.md
@@ -1107,13 +1107,13 @@
     - [x] T019.2.3.7 Total field
   - [x] T019.2.4 Sync field selection with PDF viewer bbox
 
-- [ ] **T019.3** Create line items table
-  - [ ] T019.3.1 [P] Write test for line items display
-  - [ ] T019.3.2 Create `LineItemsTable.tsx` component
-  - [ ] T019.3.3 Display editable table rows
-  - [ ] T019.3.4 Support row editing
-  - [ ] T019.3.5 Auto-calculate row amounts
-  - [ ] T019.3.6 Validate totals match
+- [x] **T019.3** Create line items table ✅ 2025-12-18
+  - [x] T019.3.1 [P] Write test for line items display
+  - [x] T019.3.2 Create `LineItemsTable.tsx` component
+  - [x] T019.3.3 Display editable table rows
+  - [x] T019.3.4 Support row editing
+  - [x] T019.3.5 Auto-calculate row amounts
+  - [x] T019.3.6 Validate totals match
 
 **Checkpoint**: All fields editable with confidence indicators
 


### PR DESCRIPTION
Add editable line items table component that displays invoice line items with inline row editing, auto-calculates amounts (quantity × unitPrice), and validates calculated total against expected subtotal.

- Create LineItemsTable.tsx with row editing support
- Add Enter/Escape keyboard handling for save/cancel
- Implement auto-calculation of row amounts
- Add totals comparison with match/mismatch indicators
- Support currency formatting with thousand separators
- Include 37 passing tests