### PR TITLE
feat(T020.3): implement form validation hook for desktop app

### DIFF
--- a/desktop-app/src/renderer/hooks/useFormValidation.ts
+++ b/desktop-app/src/renderer/hooks/useFormValidation.ts
@@ -1,0 +1,345 @@
+/**
+ * T020.3 - Form Validation Hook
+ *
+ * Hook for validating invoice form data including:
+ * - RFC validation on field blur
+ * - Totals validation (subtotal + IVA = total)
+ * - Inline error tracking
+ * - Overall form validity for "Validar" button
+ *
+ * All error messages are in Spanish.
+ */
+
+import { useState, useCallback, useEffect, useMemo } from 'react';
+import type { InvoiceExtraction } from '../types';
+import type { InvoiceFieldKey } from '../components/InvoiceForm';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Validation errors by field key
+ */
+export type ValidationErrors = Partial<Record<InvoiceFieldKey | 'ivaCalculation', string>>;
+
+/**
+ * Return type for useFormValidation hook
+ */
+export interface FormValidationState {
+  /** Current validation errors */
+  errors: ValidationErrors;
+  /** Whether the form is valid (no errors) */
+  isValid: boolean;
+  /** Validate a specific field */
+  validateField: (fieldKey: InvoiceFieldKey, value: string) => string | undefined;
+  /** Validate totals (subtotal + IVA = total) */
+  validateTotals: () => void;
+  /** Validate all fields and totals */
+  validateAll: () => boolean;
+  /** Clear error for a specific field */
+  clearError: (fieldKey: InvoiceFieldKey) => void;
+  /** Clear all errors */
+  clearAllErrors: () => void;
+  /** Get error message for a specific field */
+  getFieldError: (fieldKey: InvoiceFieldKey) => string | undefined;
+}
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Default IVA rate in Mexico (16%) */
+const DEFAULT_IVA_RATE = 0.16;
+
+/** Tolerance for rounding differences in amounts */
+const AMOUNT_TOLERANCE = 0.02;
+
+// =============================================================================
+// Validation Functions
+// =============================================================================
+
+/**
+ * Parse amount string to number, removing formatting
+ */
+function parseAmount(value: string): number {
+  if (!value) return 0;
+  // Remove $, commas, and whitespace
+  const cleaned = value.replace(/[$,\s]/g, '');
+  const parsed = parseFloat(cleaned);
+  return isNaN(parsed) ? 0 : parsed;
+}
+
+/**
+ * Validate RFC format
+ * @param rfc - RFC string to validate
+ * @returns Error message or undefined if valid
+ */
+function validateRfc(rfc: string): string | undefined {
+  // Empty is allowed (required validation is separate)
+  if (!rfc || !rfc.trim()) {
+    return undefined;
+  }
+
+  const normalized = rfc.trim().toUpperCase();
+
+  // Check length
+  if (normalized.length < 12 || normalized.length > 13) {
+    return 'El RFC debe tener 12 o 13 caracteres';
+  }
+
+  // Check pattern: only letters and numbers
+  const rfcPattern = /^[A-ZÑ&0-9]+$/;
+  if (!rfcPattern.test(normalized)) {
+    return 'El RFC solo puede contener letras y números';
+  }
+
+  return undefined;
+}
+
+/**
+ * Validate date format
+ * @param date - Date string to validate
+ * @returns Error message or undefined if valid
+ */
+function validateDate(date: string): string | undefined {
+  if (!date || !date.trim()) {
+    return undefined;
+  }
+
+  // ISO format: YYYY-MM-DD
+  const isoRegex = /^\d{4}-\d{2}-\d{2}$/;
+  // Mexican format: DD/MM/YYYY
+  const mxRegex = /^\d{2}\/\d{2}\/\d{4}$/;
+
+  if (!isoRegex.test(date) && !mxRegex.test(date)) {
+    return 'Formato de fecha inválido (use YYYY-MM-DD o DD/MM/YYYY)';
+  }
+
+  return undefined;
+}
+
+/**
+ * Validate amount format
+ * @param amount - Amount string to validate
+ * @returns Error message or undefined if valid
+ */
+function validateAmount(amount: string): string | undefined {
+  if (!amount || !amount.trim()) {
+    return undefined;
+  }
+
+  const parsed = parseAmount(amount);
+  if (isNaN(parsed)) {
+    return 'Monto inválido';
+  }
+
+  return undefined;
+}
+
+// =============================================================================
+// Hook Implementation
+// =============================================================================
+
+/**
+ * Hook for form validation
+ *
+ * @param extraction - Invoice extraction data
+ * @returns Form validation state and functions
+ *
+ * @example
+ * ```tsx
+ * const { errors, isValid, validateField, validateAll } = useFormValidation(extraction);
+ *
+ * // Validate on blur
+ * <input onBlur={() => validateField('vendorRfc', value)} />
+ *
+ * // Check validity for button
+ * <button disabled={!isValid}>Validar</button>
+ * ```
+ */
+export function useFormValidation(
+  extraction: InvoiceExtraction | null
+): FormValidationState {
+  const [errors, setErrors] = useState<ValidationErrors>({});
+
+  // Clear errors when extraction changes
+  useEffect(() => {
+    setErrors({});
+  }, [extraction]);
+
+  /**
+   * Calculate isValid from errors
+   */
+  const isValid = useMemo(() => {
+    return Object.keys(errors).length === 0;
+  }, [errors]);
+
+  /**
+   * Validate a specific field
+   */
+  const validateField = useCallback(
+    (fieldKey: InvoiceFieldKey, value: string): string | undefined => {
+      let error: string | undefined;
+
+      switch (fieldKey) {
+        case 'vendorRfc':
+          error = validateRfc(value);
+          break;
+        case 'invoiceDate':
+          error = validateDate(value);
+          break;
+        case 'subtotal':
+        case 'ivaAmount':
+        case 'total':
+          error = validateAmount(value);
+          break;
+        default:
+          // No validation for other fields
+          error = undefined;
+      }
+
+      setErrors((prev) => {
+        if (error) {
+          return { ...prev, [fieldKey]: error };
+        } else {
+          const { [fieldKey]: _, ...rest } = prev;
+          return rest;
+        }
+      });
+
+      return error;
+    },
+    []
+  );
+
+  /**
+   * Validate totals (IVA and total calculations)
+   */
+  const validateTotals = useCallback(() => {
+    if (!extraction) return;
+
+    const subtotal = parseAmount(extraction.subtotal.value);
+    const ivaAmount = parseAmount(extraction.ivaAmount.value);
+    const total = parseAmount(extraction.total.value);
+
+    const newErrors: ValidationErrors = {};
+
+    // Validate IVA calculation (subtotal * 16% = IVA)
+    const expectedIva = subtotal * DEFAULT_IVA_RATE;
+    const ivaDifference = Math.abs(ivaAmount - expectedIva);
+
+    if (ivaDifference > AMOUNT_TOLERANCE && subtotal > 0) {
+      // Check if it might be exempt (IVA = 0)
+      if (ivaAmount !== 0) {
+        newErrors.ivaAmount = `El IVA calculado ($${expectedIva.toFixed(2)}) no coincide con el IVA ingresado ($${ivaAmount.toFixed(2)})`;
+      }
+    }
+
+    // Validate total calculation (subtotal + IVA = total)
+    const expectedTotal = subtotal + ivaAmount;
+    const totalDifference = Math.abs(total - expectedTotal);
+
+    if (totalDifference > AMOUNT_TOLERANCE) {
+      newErrors.total = `El total calculado ($${expectedTotal.toFixed(2)}) no coincide con el total ingresado ($${total.toFixed(2)})`;
+    }
+
+    setErrors((prev) => {
+      // Remove old total/iva errors and add new ones
+      const { total: _, ivaAmount: __, ...rest } = prev;
+      return { ...rest, ...newErrors };
+    });
+  }, [extraction]);
+
+  /**
+   * Validate all fields and return overall validity
+   */
+  const validateAll = useCallback((): boolean => {
+    if (!extraction) return true;
+
+    const allErrors: ValidationErrors = {};
+
+    // Validate RFC
+    const rfcError = validateRfc(extraction.vendorRfc.value);
+    if (rfcError) allErrors.vendorRfc = rfcError;
+
+    // Validate date
+    const dateError = validateDate(extraction.invoiceDate.value);
+    if (dateError) allErrors.invoiceDate = dateError;
+
+    // Validate amounts
+    const subtotalError = validateAmount(extraction.subtotal.value);
+    if (subtotalError) allErrors.subtotal = subtotalError;
+
+    const ivaError = validateAmount(extraction.ivaAmount.value);
+    if (ivaError) allErrors.ivaAmount = ivaError;
+
+    const totalError = validateAmount(extraction.total.value);
+    if (totalError) allErrors.total = totalError;
+
+    // Validate totals calculations
+    const subtotal = parseAmount(extraction.subtotal.value);
+    const ivaAmount = parseAmount(extraction.ivaAmount.value);
+    const total = parseAmount(extraction.total.value);
+
+    // IVA calculation
+    const expectedIva = subtotal * DEFAULT_IVA_RATE;
+    const ivaDifference = Math.abs(ivaAmount - expectedIva);
+
+    if (ivaDifference > AMOUNT_TOLERANCE && subtotal > 0 && ivaAmount !== 0) {
+      allErrors.ivaAmount = `El IVA calculado ($${expectedIva.toFixed(2)}) no coincide con el IVA ingresado ($${ivaAmount.toFixed(2)})`;
+    }
+
+    // Total calculation
+    const expectedTotal = subtotal + ivaAmount;
+    const totalDifference = Math.abs(total - expectedTotal);
+
+    if (totalDifference > AMOUNT_TOLERANCE) {
+      allErrors.total = `El total calculado ($${expectedTotal.toFixed(2)}) no coincide con el total ingresado ($${total.toFixed(2)})`;
+    }
+
+    setErrors(allErrors);
+
+    return Object.keys(allErrors).length === 0;
+  }, [extraction]);
+
+  /**
+   * Clear error for a specific field
+   */
+  const clearError = useCallback((fieldKey: InvoiceFieldKey) => {
+    setErrors((prev) => {
+      const { [fieldKey]: _, ...rest } = prev;
+      return rest;
+    });
+  }, []);
+
+  /**
+   * Clear all errors
+   */
+  const clearAllErrors = useCallback(() => {
+    setErrors({});
+  }, []);
+
+  /**
+   * Get error message for a specific field
+   */
+  const getFieldError = useCallback(
+    (fieldKey: InvoiceFieldKey): string | undefined => {
+      return errors[fieldKey];
+    },
+    [errors]
+  );
+
+  return {
+    errors,
+    isValid,
+    validateField,
+    validateTotals,
+    validateAll,
+    clearError,
+    clearAllErrors,
+    getFieldError,
+  };
+}
+
+export default useFormValidation;

--- a/desktop-app/tests/renderer/hooks/useFormValidation.test.tsx
+++ b/desktop-app/tests/renderer/hooks/useFormValidation.test.tsx
@@ -1,0 +1,616 @@
+/**
+ * T020.3 - Form Validation Hook Tests
+ *
+ * Tests for useFormValidation hook that:
+ * - Validates RFC on field blur
+ * - Validates totals on amount changes
+ * - Shows inline validation errors in Spanish
+ * - Tracks form validity for "Validar" button
+ *
+ * Uses Tailwind CSS for styling.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+function createMockExtraction() {
+  return {
+    vendorRfc: {
+      fieldName: 'vendorRfc',
+      value: 'XAXX010101000',
+      confidence: 95,
+      userVerified: false,
+    },
+    vendorName: {
+      fieldName: 'vendorName',
+      value: 'Empresa de Prueba SA de CV',
+      confidence: 92,
+      userVerified: false,
+    },
+    invoiceNumber: {
+      fieldName: 'invoiceNumber',
+      value: 'A-001',
+      confidence: 98,
+      userVerified: false,
+    },
+    invoiceDate: {
+      fieldName: 'invoiceDate',
+      value: '2024-01-15',
+      confidence: 90,
+      userVerified: false,
+    },
+    subtotal: {
+      fieldName: 'subtotal',
+      value: '1000.00',
+      confidence: 88,
+      userVerified: false,
+    },
+    ivaAmount: {
+      fieldName: 'ivaAmount',
+      value: '160.00',
+      confidence: 88,
+      userVerified: false,
+    },
+    total: {
+      fieldName: 'total',
+      value: '1160.00',
+      confidence: 90,
+      userVerified: false,
+    },
+    lineItems: [],
+    sourceType: 'text_based' as const,
+    processingTimeMs: 1500,
+  };
+}
+
+// =============================================================================
+// Hook Export Tests
+// =============================================================================
+
+describe('T020.3.1 - useFormValidation Hook Export', () => {
+  test('should export useFormValidation hook', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    expect(useFormValidation).toBeDefined();
+    expect(typeof useFormValidation).toBe('function');
+  });
+
+  test('should export FormValidationState type', () => {
+    const module = require('../../../src/renderer/hooks/useFormValidation');
+    // Type exports are verified by TypeScript compilation
+    expect(module).toBeDefined();
+  });
+});
+
+// =============================================================================
+// Hook Initialization Tests
+// =============================================================================
+
+describe('T020.3.1 - Hook Initialization', () => {
+  test('should initialize with empty errors', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    expect(result.current.errors).toEqual({});
+  });
+
+  test('should initialize as valid when extraction is correct', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    expect(result.current.isValid).toBe(true);
+  });
+
+  test('should provide validateField function', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    expect(result.current.validateField).toBeDefined();
+    expect(typeof result.current.validateField).toBe('function');
+  });
+
+  test('should provide validateTotals function', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    expect(result.current.validateTotals).toBeDefined();
+    expect(typeof result.current.validateTotals).toBe('function');
+  });
+
+  test('should provide validateAll function', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    expect(result.current.validateAll).toBeDefined();
+    expect(typeof result.current.validateAll).toBe('function');
+  });
+
+  test('should provide clearError function', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    expect(result.current.clearError).toBeDefined();
+    expect(typeof result.current.clearError).toBe('function');
+  });
+});
+
+// =============================================================================
+// T020.3.2 - RFC Validation Tests
+// =============================================================================
+
+describe('T020.3.2 - RFC Validation on Blur', () => {
+  test('should validate valid 13-char RFC (persona física)', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+    extraction.vendorRfc.value = 'XAXX010101000';
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    act(() => {
+      result.current.validateField('vendorRfc', 'XAXX010101000');
+    });
+
+    expect(result.current.errors.vendorRfc).toBeUndefined();
+  });
+
+  test('should validate valid 12-char RFC (persona moral)', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    act(() => {
+      result.current.validateField('vendorRfc', 'XAX010101000');
+    });
+
+    expect(result.current.errors.vendorRfc).toBeUndefined();
+  });
+
+  test('should set error for invalid RFC length', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    act(() => {
+      result.current.validateField('vendorRfc', 'INVALID');
+    });
+
+    expect(result.current.errors.vendorRfc).toBeDefined();
+    expect(result.current.errors.vendorRfc).toContain('RFC');
+  });
+
+  test('should set error for RFC with special characters', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    act(() => {
+      result.current.validateField('vendorRfc', 'XAXX-010101-000');
+    });
+
+    expect(result.current.errors.vendorRfc).toBeDefined();
+  });
+
+  test('should accept lowercase RFC and consider it valid', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    act(() => {
+      result.current.validateField('vendorRfc', 'xaxx010101000');
+    });
+
+    expect(result.current.errors.vendorRfc).toBeUndefined();
+  });
+
+  test('should allow empty RFC (optional field)', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    act(() => {
+      result.current.validateField('vendorRfc', '');
+    });
+
+    // Empty is allowed (required validation is separate)
+    expect(result.current.errors.vendorRfc).toBeUndefined();
+  });
+
+  test('should return error message in Spanish', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    act(() => {
+      result.current.validateField('vendorRfc', 'INVALID');
+    });
+
+    // Should be in Spanish
+    expect(result.current.errors.vendorRfc).toMatch(/caracteres|inválido|RFC/i);
+  });
+});
+
+// =============================================================================
+// T020.3.3 - Totals Validation Tests
+// =============================================================================
+
+describe('T020.3.3 - Validate Totals on Amount Changes', () => {
+  test('should validate correct totals (subtotal + IVA = total)', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+    extraction.subtotal.value = '1000.00';
+    extraction.ivaAmount.value = '160.00';
+    extraction.total.value = '1160.00';
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    act(() => {
+      result.current.validateTotals();
+    });
+
+    expect(result.current.errors.total).toBeUndefined();
+    expect(result.current.errors.ivaAmount).toBeUndefined();
+  });
+
+  test('should set error when total does not match', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+    extraction.subtotal.value = '1000.00';
+    extraction.ivaAmount.value = '160.00';
+    extraction.total.value = '1200.00'; // Should be 1160.00
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    act(() => {
+      result.current.validateTotals();
+    });
+
+    expect(result.current.errors.total).toBeDefined();
+    expect(result.current.errors.total).toContain('total');
+  });
+
+  test('should set error when IVA calculation is wrong', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+    extraction.subtotal.value = '1000.00';
+    extraction.ivaAmount.value = '100.00'; // Should be 160.00 (16%)
+    extraction.total.value = '1100.00';
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    act(() => {
+      result.current.validateTotals();
+    });
+
+    expect(result.current.errors.ivaAmount).toBeDefined();
+    expect(result.current.errors.ivaAmount).toContain('IVA');
+  });
+
+  test('should allow small rounding differences (±0.02)', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+    extraction.subtotal.value = '100.00';
+    extraction.ivaAmount.value = '16.01'; // Slight rounding
+    extraction.total.value = '116.01';
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    act(() => {
+      result.current.validateTotals();
+    });
+
+    // Should allow small rounding difference
+    expect(result.current.errors.ivaAmount).toBeUndefined();
+  });
+
+  test('should handle amounts with comma separators', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+    extraction.subtotal.value = '1,000.00';
+    extraction.ivaAmount.value = '160.00';
+    extraction.total.value = '1,160.00';
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    act(() => {
+      result.current.validateTotals();
+    });
+
+    expect(result.current.errors.total).toBeUndefined();
+  });
+
+  test('should handle amounts with $ prefix', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+    extraction.subtotal.value = '$1000.00';
+    extraction.ivaAmount.value = '$160.00';
+    extraction.total.value = '$1160.00';
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    act(() => {
+      result.current.validateTotals();
+    });
+
+    expect(result.current.errors.total).toBeUndefined();
+  });
+
+  test('should return error messages in Spanish', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+    extraction.subtotal.value = '1000.00';
+    extraction.ivaAmount.value = '160.00';
+    extraction.total.value = '2000.00'; // Wrong
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    act(() => {
+      result.current.validateTotals();
+    });
+
+    // Should be in Spanish
+    expect(result.current.errors.total).toMatch(/total|coincide|calculado/i);
+  });
+});
+
+// =============================================================================
+// T020.3.4 - Inline Validation Errors Tests
+// =============================================================================
+
+describe('T020.3.4 - Show Inline Validation Errors in Spanish', () => {
+  test('should provide error for specific field', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    act(() => {
+      result.current.validateField('vendorRfc', 'BAD');
+    });
+
+    expect(result.current.errors.vendorRfc).toBeDefined();
+  });
+
+  test('should provide getFieldError helper', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    act(() => {
+      result.current.validateField('vendorRfc', 'BAD');
+    });
+
+    const error = result.current.getFieldError('vendorRfc');
+    expect(error).toBeDefined();
+  });
+
+  test('should return undefined for field without error', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    const error = result.current.getFieldError('vendorName');
+    expect(error).toBeUndefined();
+  });
+
+  test('should clear error when clearError is called', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    act(() => {
+      result.current.validateField('vendorRfc', 'BAD');
+    });
+    expect(result.current.errors.vendorRfc).toBeDefined();
+
+    act(() => {
+      result.current.clearError('vendorRfc');
+    });
+    expect(result.current.errors.vendorRfc).toBeUndefined();
+  });
+
+  test('should clear all errors when clearAllErrors is called', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+    extraction.total.value = '9999.00'; // Wrong
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    act(() => {
+      result.current.validateField('vendorRfc', 'BAD');
+      result.current.validateTotals();
+    });
+    expect(Object.keys(result.current.errors).length).toBeGreaterThan(0);
+
+    act(() => {
+      result.current.clearAllErrors();
+    });
+    expect(result.current.errors).toEqual({});
+  });
+});
+
+// =============================================================================
+// T020.3.5 - Form Validity Tests
+// =============================================================================
+
+describe('T020.3.5 - Enable Validar Button Only When No Errors', () => {
+  test('should be valid when no errors', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    expect(result.current.isValid).toBe(true);
+  });
+
+  test('should be invalid when there are errors', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    act(() => {
+      result.current.validateField('vendorRfc', 'BAD');
+    });
+
+    expect(result.current.isValid).toBe(false);
+  });
+
+  test('should become valid again after clearing errors', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    act(() => {
+      result.current.validateField('vendorRfc', 'BAD');
+    });
+    expect(result.current.isValid).toBe(false);
+
+    act(() => {
+      result.current.clearError('vendorRfc');
+    });
+    expect(result.current.isValid).toBe(true);
+  });
+
+  test('validateAll should return true when all valid', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    let isValid: boolean = false;
+    act(() => {
+      isValid = result.current.validateAll();
+    });
+
+    expect(isValid).toBe(true);
+  });
+
+  test('validateAll should return false when any invalid', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+    extraction.vendorRfc.value = 'BAD'; // Invalid
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    let isValid: boolean = true;
+    act(() => {
+      isValid = result.current.validateAll();
+    });
+
+    expect(isValid).toBe(false);
+  });
+
+  test('validateAll should check totals', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+    extraction.total.value = '9999.00'; // Wrong total
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    let isValid: boolean = true;
+    act(() => {
+      isValid = result.current.validateAll();
+    });
+
+    expect(isValid).toBe(false);
+    expect(result.current.errors.total).toBeDefined();
+  });
+});
+
+// =============================================================================
+// Edge Cases
+// =============================================================================
+
+describe('Edge Cases', () => {
+  test('should handle null extraction gracefully', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+
+    // Should not throw
+    expect(() => {
+      renderHook(() => useFormValidation(null as any));
+    }).not.toThrow();
+  });
+
+  test('should update when extraction changes', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction1 = createMockExtraction();
+    extraction1.vendorRfc.value = 'BAD';
+
+    const extraction2 = createMockExtraction();
+    extraction2.vendorRfc.value = 'XAXX010101000';
+
+    const { result, rerender } = renderHook(
+      ({ extraction }) => useFormValidation(extraction),
+      { initialProps: { extraction: extraction1 } }
+    );
+
+    act(() => {
+      result.current.validateAll();
+    });
+    expect(result.current.isValid).toBe(false);
+
+    // Rerender with new extraction
+    rerender({ extraction: extraction2 });
+
+    // Errors should be cleared on new extraction
+    expect(result.current.errors).toEqual({});
+    expect(result.current.isValid).toBe(true);
+  });
+
+  test('should handle zero amounts', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+    extraction.subtotal.value = '0.00';
+    extraction.ivaAmount.value = '0.00';
+    extraction.total.value = '0.00';
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    act(() => {
+      result.current.validateTotals();
+    });
+
+    // Zero invoice should be valid
+    expect(result.current.errors.total).toBeUndefined();
+  });
+
+  test('should handle very large amounts', () => {
+    const { useFormValidation } = require('../../../src/renderer/hooks/useFormValidation');
+    const extraction = createMockExtraction();
+    extraction.subtotal.value = '1000000.00';
+    extraction.ivaAmount.value = '160000.00';
+    extraction.total.value = '1160000.00';
+
+    const { result } = renderHook(() => useFormValidation(extraction));
+
+    act(() => {
+      result.current.validateTotals();
+    });
+
+    expect(result.current.errors.total).toBeUndefined();
+  });
+});

--- a/log_files/T020.3_FormValidation_Log.md
+++ b/log_files/T020.3_FormValidation_Log.md
@@ -1,0 +1,112 @@
+# T020.3 Implementation Log: Form Validation Hook
+
+## Date: 2025-12-18
+
+## Task Description
+Implement form validation in desktop app including RFC validation on field blur, totals validation on amount changes, inline validation errors in Spanish, and form validity tracking for the "Validar" button.
+
+## Subtasks Completed
+
+### T020.3.1 - Write test for form validation
+Created comprehensive test suite with 37 tests covering:
+- Hook export and initialization
+- RFC validation on blur
+- Totals validation (subtotal + IVA = total)
+- Inline error display
+- Form validity tracking
+- Edge cases (null, large amounts, etc.)
+
+### T020.3.2 - Validate RFC on field blur
+Created `validateField` function that:
+- Validates RFC length (12-13 characters)
+- Validates RFC characters (alphanumeric only)
+- Accepts lowercase (case-insensitive)
+- Allows empty values (required validation is separate)
+- Returns Spanish error messages
+
+### T020.3.3 - Validate totals on amount changes
+Created `validateTotals` function that:
+- Validates IVA calculation (subtotal × 16% = IVA)
+- Validates total calculation (subtotal + IVA = total)
+- Allows ±0.02 tolerance for rounding differences
+- Handles formatted amounts ($, commas)
+
+### T020.3.4 - Show inline validation errors in Spanish
+Implemented error tracking with:
+- `errors` object keyed by field name
+- `getFieldError(fieldKey)` helper function
+- `clearError(fieldKey)` to remove specific errors
+- `clearAllErrors()` to reset all errors
+- All error messages in Spanish
+
+### T020.3.5 - Enable "Validar" button only when no errors
+Implemented form validity tracking:
+- `isValid` boolean computed from errors
+- `validateAll()` validates all fields and returns boolean
+- Errors automatically clear when extraction changes
+
+## Files Created
+- `desktop-app/src/renderer/hooks/useFormValidation.ts`
+- `desktop-app/tests/renderer/hooks/useFormValidation.test.tsx`
+
+## Test Results
+- Total tests: 37
+- Passed: 37
+- Failed: 0
+
+## Hook API
+
+```typescript
+interface FormValidationState {
+  errors: ValidationErrors;
+  isValid: boolean;
+  validateField: (fieldKey: InvoiceFieldKey, value: string) => string | undefined;
+  validateTotals: () => void;
+  validateAll: () => boolean;
+  clearError: (fieldKey: InvoiceFieldKey) => void;
+  clearAllErrors: () => void;
+  getFieldError: (fieldKey: InvoiceFieldKey) => string | undefined;
+}
+```
+
+## Usage Example
+
+```tsx
+import { useFormValidation } from './hooks/useFormValidation';
+
+function InvoiceFormWithValidation({ extraction, onValidate }) {
+  const { errors, isValid, validateField, validateAll } = useFormValidation(extraction);
+
+  const handleBlur = (fieldKey: InvoiceFieldKey, value: string) => {
+    validateField(fieldKey, value);
+  };
+
+  const handleValidate = () => {
+    if (validateAll()) {
+      onValidate(extraction);
+    }
+  };
+
+  return (
+    <div>
+      <InvoiceForm
+        extraction={extraction}
+        onChange={(field, value) => {
+          // Update extraction...
+          validateField(field, value);
+        }}
+      />
+      {errors.vendorRfc && (
+        <span className="text-red-500">{errors.vendorRfc}</span>
+      )}
+      <button
+        onClick={handleValidate}
+        disabled={!isValid}
+        className={isValid ? 'bg-blue-500' : 'bg-gray-300'}
+      >
+        Validar
+      </button>
+    </div>
+  );
+}
+```

--- a/log_learn/T020.3_FormValidation_LearnLog.md
+++ b/log_learn/T020.3_FormValidation_LearnLog.md
@@ -1,0 +1,150 @@
+# T020.3 Learning Log: Form Validation Hook
+
+## Date: 2025-12-18
+
+## Concepts Learned
+
+### 1. React Hook Design Pattern
+Designed a reusable validation hook that encapsulates all validation logic:
+
+```typescript
+export function useFormValidation(extraction: InvoiceExtraction | null): FormValidationState {
+  const [errors, setErrors] = useState<ValidationErrors>({});
+
+  const isValid = useMemo(() => Object.keys(errors).length === 0, [errors]);
+
+  const validateField = useCallback((fieldKey, value) => {
+    // Validate and update errors
+  }, []);
+
+  return { errors, isValid, validateField, /* ... */ };
+}
+```
+
+Benefits:
+- Separates validation logic from UI
+- Reusable across components
+- Testable in isolation
+- Clear API contract
+
+### 2. Error State Management
+Used object-keyed state for field errors:
+
+```typescript
+type ValidationErrors = Partial<Record<InvoiceFieldKey, string>>;
+
+// Add error
+setErrors((prev) => ({ ...prev, [fieldKey]: error }));
+
+// Remove error
+setErrors((prev) => {
+  const { [fieldKey]: _, ...rest } = prev;
+  return rest;
+});
+```
+
+Advantages:
+- O(1) lookup by field key
+- Easy to check specific field errors
+- Trivial to compute overall validity
+
+### 3. Parsing Formatted Currency
+Implemented robust amount parsing that handles various formats:
+
+```typescript
+function parseAmount(value: string): number {
+  if (!value) return 0;
+  // Remove $, commas, and whitespace
+  const cleaned = value.replace(/[$,\s]/g, '');
+  const parsed = parseFloat(cleaned);
+  return isNaN(parsed) ? 0 : parsed;
+}
+```
+
+Handles:
+- `$1,000.00` → 1000
+- `1000.00` → 1000
+- `1,000` → 1000
+- Empty/null → 0
+
+### 4. Tolerance in Financial Validation
+Used tolerance for amount comparisons instead of exact equality:
+
+```typescript
+const AMOUNT_TOLERANCE = 0.02;
+
+const difference = Math.abs(calculated - actual);
+if (difference > AMOUNT_TOLERANCE) {
+  // Error
+}
+```
+
+Reasons:
+- Floating-point precision issues
+- Rounding differences between systems
+- Real-world data variations
+
+### 5. Effect-Based State Reset
+Used `useEffect` to clear errors when extraction changes:
+
+```typescript
+useEffect(() => {
+  setErrors({});
+}, [extraction]);
+```
+
+This ensures:
+- New extraction starts fresh
+- No stale errors from previous data
+- Clean UX when switching invoices
+
+### 6. Derived State with useMemo
+Computed `isValid` from errors using `useMemo`:
+
+```typescript
+const isValid = useMemo(() => {
+  return Object.keys(errors).length === 0;
+}, [errors]);
+```
+
+Benefits:
+- Only recalculates when errors change
+- Consistent computed value
+- No redundant state
+
+## Best Practices Identified
+
+1. **Return undefined for valid**: Functions return `undefined` when valid, error string when invalid
+2. **Spanish error messages**: All errors in Spanish for Mexican users
+3. **Allow empty values**: Empty fields are valid (required validation is separate concern)
+4. **Case-insensitive validation**: RFC accepts lowercase, validates uppercase
+5. **Pure validation functions**: Validation logic is pure and easily testable
+
+## Patterns to Reuse
+
+### Validation Result Pattern
+```typescript
+function validate(value: string): string | undefined {
+  if (isInvalid) return 'Error message';
+  return undefined;
+}
+```
+
+### Error Object Management
+```typescript
+// Add error
+{ ...prev, [key]: error }
+
+// Remove error
+const { [key]: _, ...rest } = prev;
+```
+
+### Amount Parsing Pattern
+```typescript
+value.replace(/[$,\s]/g, '')
+```
+
+## Questions for Future
+- Should we debounce validation for performance?
+- Should validateAll stop on first error or collect all?
+- How to handle async validation (e.g., RFC lookup)?

--- a/log_tests/T020.3_FormValidation_TestLog.md
+++ b/log_tests/T020.3_FormValidation_TestLog.md
@@ -1,0 +1,84 @@
+# T020.3 Test Log: Form Validation Hook
+
+## Date: 2025-12-18
+
+## Test File
+`desktop-app/tests/renderer/hooks/useFormValidation.test.tsx`
+
+## Test Results Summary
+- **Total Tests**: 37
+- **Passed**: 37
+- **Failed**: 0
+- **Duration**: ~5 seconds
+
+## Test Suites
+
+### T020.3.1 - useFormValidation Hook Export (2 tests)
+| Test | Status | Description |
+|------|--------|-------------|
+| should export useFormValidation hook | ✅ | Hook is exported |
+| should export FormValidationState type | ✅ | Types exported |
+
+### T020.3.1 - Hook Initialization (6 tests)
+| Test | Status | Description |
+|------|--------|-------------|
+| should initialize with empty errors | ✅ | errors = {} |
+| should initialize as valid when extraction is correct | ✅ | isValid = true |
+| should provide validateField function | ✅ | Function available |
+| should provide validateTotals function | ✅ | Function available |
+| should provide validateAll function | ✅ | Function available |
+| should provide clearError function | ✅ | Function available |
+
+### T020.3.2 - RFC Validation on Blur (7 tests)
+| Test | Status | Description |
+|------|--------|-------------|
+| should validate valid 13-char RFC | ✅ | Persona física |
+| should validate valid 12-char RFC | ✅ | Persona moral |
+| should set error for invalid RFC length | ✅ | <12 or >13 chars |
+| should set error for RFC with special characters | ✅ | Hyphens rejected |
+| should accept lowercase RFC | ✅ | Case-insensitive |
+| should allow empty RFC | ✅ | Optional field |
+| should return error message in Spanish | ✅ | Spanish message |
+
+### T020.3.3 - Validate Totals (7 tests)
+| Test | Status | Description |
+|------|--------|-------------|
+| should validate correct totals | ✅ | 1000 + 160 = 1160 |
+| should set error when total does not match | ✅ | Wrong total |
+| should set error when IVA calculation is wrong | ✅ | Wrong IVA |
+| should allow small rounding differences | ✅ | ±0.02 tolerance |
+| should handle amounts with comma separators | ✅ | 1,000.00 |
+| should handle amounts with $ prefix | ✅ | $1000.00 |
+| should return error messages in Spanish | ✅ | Spanish message |
+
+### T020.3.4 - Inline Validation Errors (5 tests)
+| Test | Status | Description |
+|------|--------|-------------|
+| should provide error for specific field | ✅ | errors.vendorRfc |
+| should provide getFieldError helper | ✅ | Helper function |
+| should return undefined for field without error | ✅ | No false positives |
+| should clear error when clearError is called | ✅ | Remove single error |
+| should clear all errors when clearAllErrors is called | ✅ | Reset all |
+
+### T020.3.5 - Form Validity (6 tests)
+| Test | Status | Description |
+|------|--------|-------------|
+| should be valid when no errors | ✅ | isValid = true |
+| should be invalid when there are errors | ✅ | isValid = false |
+| should become valid again after clearing errors | ✅ | State updates |
+| validateAll should return true when all valid | ✅ | Returns boolean |
+| validateAll should return false when any invalid | ✅ | Returns false |
+| validateAll should check totals | ✅ | Validates totals |
+
+### Edge Cases (4 tests)
+| Test | Status | Description |
+|------|--------|-------------|
+| should handle null extraction gracefully | ✅ | No crash |
+| should update when extraction changes | ✅ | Clears errors |
+| should handle zero amounts | ✅ | Zero invoice valid |
+| should handle very large amounts | ✅ | 1,000,000+ |
+
+## Test Execution Command
+```bash
+cd desktop-app && npm test -- --testPathPattern="useFormValidation"
+```

--- a/specs/001-windows-native-ai/tasks.md
+++ b/specs/001-windows-native-ai/tasks.md
@@ -1138,12 +1138,12 @@
   - [x] T020.2.5 Validate total (subtotal + iva = total)
   - [x] T020.2.6 Return validation errors/warnings
 
-- [ ] **T020.3** Implement form validation in desktop app
-  - [ ] T020.3.1 [P] Write test for form validation
-  - [ ] T020.3.2 Validate RFC on field blur
-  - [ ] T020.3.3 Validate totals on amount changes
-  - [ ] T020.3.4 Show inline validation errors in Spanish
-  - [ ] T020.3.5 Enable "Validar" button only when no errors
+- [x] **T020.3** Implement form validation in desktop app ✅ 2025-12-18
+  - [x] T020.3.1 [P] Write test for form validation
+  - [x] T020.3.2 Validate RFC on field blur
+  - [x] T020.3.3 Validate totals on amount changes
+  - [x] T020.3.4 Show inline validation errors in Spanish
+  - [x] T020.3.5 Enable "Validar" button only when no errors
 
 **Checkpoint**: Validation errors display correctly
 


### PR DESCRIPTION
Add useFormValidation hook for invoice form validation:
- Validate RFC format on field blur (12-13 alphanumeric chars)
- Validate totals (subtotal + IVA = total) with ±0.02 tolerance
- Track inline validation errors by field key
- Compute overall form validity for "Validar" button
- All error messages in Spanish
- Handle formatted amounts ($, commas)
- 37 tests passing