### PR TITLE
docs: add source installation instructions to README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,14 +68,37 @@ ContPAQ-Win uses a multi-process architecture:
 
 ## Installation
 
-> **Note**: ContPAQ-Win is currently in development. Pre-built installers will be available on the [Releases](https://github.com/danribes/contpaq-win/releases) page once the first stable version is ready. For now, you can build the installer locally (see [Building the Installer](#building-the-installer) below).
+> **Note**: ContPAQ-Win is currently in development. Pre-built installers will be available on the [Releases](https://github.com/danribes/contpaq-win/releases) page once the first stable version is ready. For now, you can build and install locally following the instructions below.
 
-### Quick Install (When Available)
+### Install from Source (Current Method)
+
+Since pre-built releases are not yet available, follow these steps to build and install:
+
+1. **Clone the repository** and ensure you have all [Development Prerequisites](#prerequisites)
+2. **Build the installer** by running from the repository root:
+   ```powershell
+   .\build.ps1
+   ```
+3. **Run the generated installer**:
+   ```powershell
+   # The installer will be at:
+   installer\output\ContPAQ-Win-0.1.0-Setup.exe
+   ```
+4. **Run the installer as Administrator** and follow the installation wizard
+5. **Launch ContPAQ-Win** from the desktop shortcut or Start Menu
+
+For detailed build options, see [Building the Installer](#building-the-installer) below.
+
+### Quick Install (When Releases Available)
+
+Once stable releases are published:
 
 1. Download `ContPAQ-Win-X.X.X-Setup.exe` from the [Releases](https://github.com/danribes/contpaq-win/releases) page
 2. Run the installer as Administrator
 3. Follow the installation wizard
 4. Launch ContPAQ-Win from the desktop shortcut or Start Menu
+
+### What the Installer Does
 
 The installer will:
 - Install prerequisites (.NET 8.0, VC++ Redistributable) if needed

--- a/README_ES.md
+++ b/README_ES.md
@@ -69,14 +69,37 @@ ContPAQ-Win utiliza una arquitectura multi-proceso:
 
 ## Instalación
 
-> **Nota**: ContPAQ-Win está actualmente en desarrollo. Los instaladores pre-compilados estarán disponibles en la página de [Releases](https://github.com/danribes/contpaq-win/releases) cuando la primera versión estable esté lista. Por ahora, puede compilar el instalador localmente (ver [Compilar el Instalador](#compilar-el-instalador) más abajo).
+> **Nota**: ContPAQ-Win está actualmente en desarrollo. Los instaladores pre-compilados estarán disponibles en la página de [Releases](https://github.com/danribes/contpaq-win/releases) cuando la primera versión estable esté lista. Por ahora, puede compilar e instalar localmente siguiendo las instrucciones a continuación.
 
-### Instalación Rápida (Cuando Esté Disponible)
+### Instalar desde Código Fuente (Método Actual)
+
+Ya que los releases pre-compilados aún no están disponibles, siga estos pasos para compilar e instalar:
+
+1. **Clonar el repositorio** y asegurarse de tener todos los [Prerrequisitos de Desarrollo](#prerrequisitos)
+2. **Compilar el instalador** ejecutando desde la raíz del repositorio:
+   ```powershell
+   .\build.ps1
+   ```
+3. **Ejecutar el instalador generado**:
+   ```powershell
+   # El instalador estará en:
+   installer\output\ContPAQ-Win-0.1.0-Setup.exe
+   ```
+4. **Ejecutar el instalador como Administrador** y seguir el asistente de instalación
+5. **Iniciar ContPAQ-Win** desde el acceso directo del escritorio o Menú Inicio
+
+Para opciones detalladas de compilación, ver [Compilar el Instalador](#compilar-el-instalador) más abajo.
+
+### Instalación Rápida (Cuando Haya Releases Disponibles)
+
+Una vez que se publiquen releases estables:
 
 1. Descargar `ContPAQ-Win-X.X.X-Setup.exe` desde la página de [Releases](https://github.com/danribes/contpaq-win/releases)
 2. Ejecutar el instalador como Administrador
 3. Seguir el asistente de instalación
 4. Iniciar ContPAQ-Win desde el acceso directo del escritorio o Menú Inicio
+
+### Qué Hace el Instalador
 
 El instalador:
 - Instala los prerrequisitos (.NET 8.0, VC++ Redistributable) si es necesario


### PR DESCRIPTION
Add clear step-by-step instructions for installing ContPAQ-Win from source using the build.ps1 script, since pre-built releases are not yet available. Instructions cover both English and Spanish READMEs.