### PR TITLE
refactor: rename app from ContPAQ-Win to ContPaq-proPDF

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# contpaq-win Development Guidelines
+# contpaq-propdf Development Guidelines
 
 Auto-generated from all feature plans. Last updated: 2025-12-15
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# ContPAQ-Win
+# ContPaq-proPDF
 
 Windows-native AI-powered invoice processing for ContPAQi accounting software.
 
 ## Overview
 
-ContPAQ-Win is a desktop application that automates invoice data extraction using AI and posts documents directly to ContPAQi. Unlike cloud-based solutions, it runs entirely on Windows without requiring Docker or WSL.
+ContPaq-proPDF is a desktop application that automates invoice data extraction using AI and posts documents directly to ContPAQi. Unlike cloud-based solutions, it runs entirely on Windows without requiring Docker or WSL.
 
 ### Key Features
 
@@ -17,7 +17,7 @@ ContPAQ-Win is a desktop application that automates invoice data extraction usin
 
 ## Architecture
 
-ContPAQ-Win uses a multi-process architecture:
+ContPaq-proPDF uses a multi-process architecture:
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -68,7 +68,7 @@ ContPAQ-Win uses a multi-process architecture:
 
 ## Installation
 
-> **Note**: ContPAQ-Win is currently in development. Pre-built installers will be available on the [Releases](https://github.com/danribes/contpaq-win/releases) page once the first stable version is ready. For now, you can build and install locally following the instructions below.
+> **Note**: ContPaq-proPDF is currently in development. Pre-built installers will be available on the [Releases](https://github.com/danribes/contpaq-win/releases) page once the first stable version is ready. For now, you can build and install locally following the instructions below.
 
 ### Install from Source (Current Method)
 
@@ -82,10 +82,10 @@ Since pre-built releases are not yet available, follow these steps to build and 
 3. **Run the generated installer**:
    ```powershell
    # The installer will be at:
-   installer\output\ContPAQ-Win-0.1.0-Setup.exe
+   installer\output\ContPaq-proPDF-0.1.0-Setup.exe
    ```
 4. **Run the installer as Administrator** and follow the installation wizard
-5. **Launch ContPAQ-Win** from the desktop shortcut or Start Menu
+5. **Launch ContPaq-proPDF** from the desktop shortcut or Start Menu
 
 For detailed build options, see [Building the Installer](#building-the-installer) below.
 
@@ -93,10 +93,10 @@ For detailed build options, see [Building the Installer](#building-the-installer
 
 Once stable releases are published:
 
-1. Download `ContPAQ-Win-X.X.X-Setup.exe` from the [Releases](https://github.com/danribes/contpaq-win/releases) page
+1. Download `ContPaq-proPDF-X.X.X-Setup.exe` from the [Releases](https://github.com/danribes/contpaq-win/releases) page
 2. Run the installer as Administrator
 3. Follow the installation wizard
-4. Launch ContPAQ-Win from the desktop shortcut or Start Menu
+4. Launch ContPaq-proPDF from the desktop shortcut or Start Menu
 
 ### What the Installer Does
 
@@ -109,11 +109,11 @@ The installer will:
 
 ### Installation Directory
 
-Default: `C:\Program Files\ContPAQ-Win`
+Default: `C:\Program Files\ContPaq-proPDF`
 
 ```
-ContPAQ-Win/
-├── ContPAQ Win.exe      # Main desktop application
+ContPaq-proPDF/
+├── ContPaq proPDF.exe      # Main desktop application
 ├── ai-service/          # AI document processing service
 ├── windows-bridge/      # ContPAQi SDK bridge
 ├── tesseract/           # OCR engine
@@ -128,8 +128,8 @@ Two services are installed and started automatically:
 
 | Service | Port | Purpose |
 |---------|------|---------|
-| ContPAQWinAIService | 8000 | AI-powered document processing |
-| ContPAQWinBridge | 5000 | ContPAQi SDK integration |
+| ContPaqProPDFAIService | 8000 | AI-powered document processing |
+| ContPaqProPDFBridge | 5000 | ContPAQi SDK integration |
 
 Both services:
 - Start automatically with Windows
@@ -139,13 +139,13 @@ Both services:
 ### Log Files
 
 Logs are stored in:
-- `%LOCALAPPDATA%\ContPAQ-Win\Logs\` - Application logs (JSON format)
-- `%PROGRAMDATA%\ContPAQ-Win\logs\` - Service stdout/stderr logs
+- `%LOCALAPPDATA%\ContPaq-proPDF\Logs\` - Application logs (JSON format)
+- `%PROGRAMDATA%\ContPaq-proPDF\logs\` - Service stdout/stderr logs
 
 ### Uninstallation
 
-1. Use Windows Settings > Apps > ContPAQ-Win > Uninstall, or
-2. Run the uninstaller from Start Menu > ContPAQ-Win > Uninstall
+1. Use Windows Settings > Apps > ContPaq-proPDF > Uninstall, or
+2. Run the uninstaller from Start Menu > ContPaq-proPDF > Uninstall
 
 The uninstaller will stop and remove both Windows services.
 
@@ -192,7 +192,7 @@ cd ai-service
 uvicorn main:app --reload --host 127.0.0.1 --port 8000
 
 # Terminal 2: Windows Bridge
-cd windows-bridge/src/ContPAQWinBridge
+cd windows-bridge/src/ContPaqProPDFBridge
 dotnet run
 
 # Terminal 3: Desktop App
@@ -249,7 +249,7 @@ Options:
    iscc contpaq-win.iss
    ```
 
-The installer will be created at `installer/output/ContPAQ-Win-X.X.X-Setup.exe`
+The installer will be created at `installer/output/ContPaq-proPDF-X.X.X-Setup.exe`
 
 ## Project Structure
 
@@ -267,8 +267,8 @@ contpaq-win/
 │       └── renderer/    # React UI components
 ├── windows-bridge/      # C#/.NET ContPAQi bridge
 │   └── src/
-│       ├── ContPAQWinBridge/        # Main project
-│       └── ContPAQWinBridge.Tests/  # Tests
+│       ├── ContPaqProPDFBridge/        # Main project
+│       └── ContPaqProPDFBridge.Tests/  # Tests
 ├── database/            # SQLite database
 │   ├── migrations/      # Schema migrations
 │   └── seed/            # Test data
@@ -316,16 +316,16 @@ dotnet test --filter "FullyQualifiedName~LoggingConfigurationTests"
 
 1. Check service status:
    ```powershell
-   Get-Service ContPAQWinAIService, ContPAQWinBridge
+   Get-Service ContPaqProPDFAIService, ContPaqProPDFBridge
    ```
 
 2. Check logs:
-   - `%PROGRAMDATA%\ContPAQ-Win\logs\ai-service-stderr.log`
-   - `%LOCALAPPDATA%\ContPAQ-Win\Logs\windows-bridge-*.log`
+   - `%PROGRAMDATA%\ContPaq-proPDF\logs\ai-service-stderr.log`
+   - `%LOCALAPPDATA%\ContPaq-proPDF\Logs\windows-bridge-*.log`
 
 3. Restart services:
    ```powershell
-   Restart-Service ContPAQWinAIService, ContPAQWinBridge
+   Restart-Service ContPaqProPDFAIService, ContPaqProPDFBridge
    ```
 
 ### ContPAQi Not Detected

--- a/README_ES.md
+++ b/README_ES.md
@@ -1,10 +1,10 @@
-# ContPAQ-Win
+# ContPaq-proPDF
 
 Procesamiento de facturas con inteligencia artificial para ContPAQi, nativo de Windows.
 
 ## Descripción General
 
-ContPAQ-Win es una aplicación de escritorio que automatiza la extracción de datos de facturas usando IA y publica documentos directamente en ContPAQi. A diferencia de soluciones en la nube, se ejecuta completamente en Windows sin requerir Docker o WSL.
+ContPaq-proPDF es una aplicación de escritorio que automatiza la extracción de datos de facturas usando IA y publica documentos directamente en ContPAQi. A diferencia de soluciones en la nube, se ejecuta completamente en Windows sin requerir Docker o WSL.
 
 ### Características Principales
 
@@ -17,7 +17,7 @@ ContPAQ-Win es una aplicación de escritorio que automatiza la extracción de da
 
 ## Arquitectura
 
-ContPAQ-Win utiliza una arquitectura multi-proceso:
+ContPaq-proPDF utiliza una arquitectura multi-proceso:
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -69,7 +69,7 @@ ContPAQ-Win utiliza una arquitectura multi-proceso:
 
 ## Instalación
 
-> **Nota**: ContPAQ-Win está actualmente en desarrollo. Los instaladores pre-compilados estarán disponibles en la página de [Releases](https://github.com/danribes/contpaq-win/releases) cuando la primera versión estable esté lista. Por ahora, puede compilar e instalar localmente siguiendo las instrucciones a continuación.
+> **Nota**: ContPaq-proPDF está actualmente en desarrollo. Los instaladores pre-compilados estarán disponibles en la página de [Releases](https://github.com/danribes/contpaq-win/releases) cuando la primera versión estable esté lista. Por ahora, puede compilar e instalar localmente siguiendo las instrucciones a continuación.
 
 ### Instalar desde Código Fuente (Método Actual)
 
@@ -83,10 +83,10 @@ Ya que los releases pre-compilados aún no están disponibles, siga estos pasos 
 3. **Ejecutar el instalador generado**:
    ```powershell
    # El instalador estará en:
-   installer\output\ContPAQ-Win-0.1.0-Setup.exe
+   installer\output\ContPaq-proPDF-0.1.0-Setup.exe
    ```
 4. **Ejecutar el instalador como Administrador** y seguir el asistente de instalación
-5. **Iniciar ContPAQ-Win** desde el acceso directo del escritorio o Menú Inicio
+5. **Iniciar ContPaq-proPDF** desde el acceso directo del escritorio o Menú Inicio
 
 Para opciones detalladas de compilación, ver [Compilar el Instalador](#compilar-el-instalador) más abajo.
 
@@ -94,10 +94,10 @@ Para opciones detalladas de compilación, ver [Compilar el Instalador](#compilar
 
 Una vez que se publiquen releases estables:
 
-1. Descargar `ContPAQ-Win-X.X.X-Setup.exe` desde la página de [Releases](https://github.com/danribes/contpaq-win/releases)
+1. Descargar `ContPaq-proPDF-X.X.X-Setup.exe` desde la página de [Releases](https://github.com/danribes/contpaq-win/releases)
 2. Ejecutar el instalador como Administrador
 3. Seguir el asistente de instalación
-4. Iniciar ContPAQ-Win desde el acceso directo del escritorio o Menú Inicio
+4. Iniciar ContPaq-proPDF desde el acceso directo del escritorio o Menú Inicio
 
 ### Qué Hace el Instalador
 
@@ -110,11 +110,11 @@ El instalador:
 
 ### Directorio de Instalación
 
-Por defecto: `C:\Program Files\ContPAQ-Win`
+Por defecto: `C:\Program Files\ContPaq-proPDF`
 
 ```
-ContPAQ-Win/
-├── ContPAQ Win.exe      # Aplicación principal
+ContPaq-proPDF/
+├── ContPaq proPDF.exe      # Aplicación principal
 ├── ai-service/          # Servicio de procesamiento de documentos con IA
 ├── windows-bridge/      # Bridge para SDK de ContPAQi
 ├── tesseract/           # Motor OCR
@@ -129,8 +129,8 @@ Se instalan e inician automáticamente dos servicios:
 
 | Servicio | Puerto | Propósito |
 |----------|--------|-----------|
-| ContPAQWinAIService | 8000 | Procesamiento de documentos con IA |
-| ContPAQWinBridge | 5000 | Integración con SDK de ContPAQi |
+| ContPaqProPDFAIService | 8000 | Procesamiento de documentos con IA |
+| ContPaqProPDFBridge | 5000 | Integración con SDK de ContPAQi |
 
 Ambos servicios:
 - Inician automáticamente con Windows
@@ -140,13 +140,13 @@ Ambos servicios:
 ### Archivos de Registro (Logs)
 
 Los registros se almacenan en:
-- `%LOCALAPPDATA%\ContPAQ-Win\Logs\` - Registros de la aplicación (formato JSON)
-- `%PROGRAMDATA%\ContPAQ-Win\logs\` - Registros stdout/stderr de servicios
+- `%LOCALAPPDATA%\ContPaq-proPDF\Logs\` - Registros de la aplicación (formato JSON)
+- `%PROGRAMDATA%\ContPaq-proPDF\logs\` - Registros stdout/stderr de servicios
 
 ### Desinstalación
 
-1. Usar Configuración de Windows > Aplicaciones > ContPAQ-Win > Desinstalar, o
-2. Ejecutar el desinstalador desde Menú Inicio > ContPAQ-Win > Desinstalar
+1. Usar Configuración de Windows > Aplicaciones > ContPaq-proPDF > Desinstalar, o
+2. Ejecutar el desinstalador desde Menú Inicio > ContPaq-proPDF > Desinstalar
 
 El desinstalador detendrá y eliminará ambos servicios de Windows.
 
@@ -193,7 +193,7 @@ cd ai-service
 uvicorn main:app --reload --host 127.0.0.1 --port 8000
 
 # Terminal 2: Windows Bridge
-cd windows-bridge/src/ContPAQWinBridge
+cd windows-bridge/src/ContPaqProPDFBridge
 dotnet run
 
 # Terminal 3: App de Escritorio
@@ -250,7 +250,7 @@ Opciones:
    iscc contpaq-win.iss
    ```
 
-El instalador se creará en `installer/output/ContPAQ-Win-X.X.X-Setup.exe`
+El instalador se creará en `installer/output/ContPaq-proPDF-X.X.X-Setup.exe`
 
 ## Estructura del Proyecto
 
@@ -268,8 +268,8 @@ contpaq-win/
 │       └── renderer/    # Componentes de UI en React
 ├── windows-bridge/      # Bridge C#/.NET para ContPAQi
 │   └── src/
-│       ├── ContPAQWinBridge/        # Proyecto principal
-│       └── ContPAQWinBridge.Tests/  # Pruebas
+│       ├── ContPaqProPDFBridge/        # Proyecto principal
+│       └── ContPaqProPDFBridge.Tests/  # Pruebas
 ├── database/            # Base de datos SQLite
 │   ├── migrations/      # Migraciones de esquema
 │   └── seed/            # Datos de prueba
@@ -317,16 +317,16 @@ dotnet test --filter "FullyQualifiedName~LoggingConfigurationTests"
 
 1. Verificar el estado de los servicios:
    ```powershell
-   Get-Service ContPAQWinAIService, ContPAQWinBridge
+   Get-Service ContPaqProPDFAIService, ContPaqProPDFBridge
    ```
 
 2. Revisar los registros:
-   - `%PROGRAMDATA%\ContPAQ-Win\logs\ai-service-stderr.log`
-   - `%LOCALAPPDATA%\ContPAQ-Win\Logs\windows-bridge-*.log`
+   - `%PROGRAMDATA%\ContPaq-proPDF\logs\ai-service-stderr.log`
+   - `%LOCALAPPDATA%\ContPaq-proPDF\Logs\windows-bridge-*.log`
 
 3. Reiniciar los servicios:
    ```powershell
-   Restart-Service ContPAQWinAIService, ContPAQWinBridge
+   Restart-Service ContPaqProPDFAIService, ContPaqProPDFBridge
    ```
 
 ### ContPAQi No Detectado

--- a/ai-service/pyproject.toml
+++ b/ai-service/pyproject.toml
@@ -5,12 +5,12 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "contpaq-win-ai-service"
 version = "0.1.0"
-description = "AI-powered invoice processing service for ContPAQ-Win"
+description = "AI-powered invoice processing service for ContPaq-proPDF"
 readme = "README.md"
 license = {text = "Proprietary"}
 requires-python = ">=3.11"
 authors = [
-    {name = "ContPAQ-Win Team"}
+    {name = "ContPaq-proPDF Team"}
 ]
 keywords = ["invoice", "ocr", "ai", "contpaqi", "pdf"]
 classifiers = [

--- a/ai-service/scripts/install-service.ps1
+++ b/ai-service/scripts/install-service.ps1
@@ -1,7 +1,7 @@
 #Requires -RunAsAdministrator
 <#
 .SYNOPSIS
-    Installs the ContPAQ-Win AI Service as a Windows Service using NSSM.
+    Installs the ContPaq-proPDF AI Service as a Windows Service using NSSM.
 
 .DESCRIPTION
     This script uses NSSM (Non-Sucking Service Manager) to install the
@@ -20,7 +20,7 @@
     .\install-service.ps1
 
 .EXAMPLE
-    .\install-service.ps1 -ServicePath "C:\Program Files\ContPAQ-Win\ai-service\contpaq-ai-service.exe"
+    .\install-service.ps1 -ServicePath "C:\Program Files\ContPaq-proPDF\ai-service\contpaq-ai-service.exe"
 
 .NOTES
     Requires Administrator privileges.
@@ -39,14 +39,14 @@ param(
 # Configuration
 # =============================================================================
 
-$ServiceName = "ContPAQWinAIService"
-$DisplayName = "ContPAQ-Win AI Service"
-$Description = "AI-powered invoice processing service for ContPAQ-Win. Provides PDF extraction, OCR, and intelligent field recognition for Mexican invoices."
+$ServiceName = "ContPaqProPDFAIService"
+$DisplayName = "ContPaq-proPDF AI Service"
+$Description = "AI-powered invoice processing service for ContPaq-proPDF. Provides PDF extraction, OCR, and intelligent field recognition for Mexican invoices."
 $Host = "127.0.0.1"
 $Port = "8000"
 
 # Log directory
-$LogDirectory = "$env:PROGRAMDATA\ContPAQ-Win\logs"
+$LogDirectory = "$env:PROGRAMDATA\ContPaq-proPDF\logs"
 
 # Restart configuration
 $RestartDelay = 5000  # 5 seconds in milliseconds
@@ -105,7 +105,7 @@ function Stop-ExistingService {
 # Main Script
 # =============================================================================
 
-Write-Log "ContPAQ-Win AI Service Installer"
+Write-Log "ContPaq-proPDF AI Service Installer"
 Write-Log "================================="
 
 # Find NSSM

--- a/ai-service/scripts/uninstall-service.ps1
+++ b/ai-service/scripts/uninstall-service.ps1
@@ -1,7 +1,7 @@
 #Requires -RunAsAdministrator
 <#
 .SYNOPSIS
-    Uninstalls the ContPAQ-Win AI Service Windows Service.
+    Uninstalls the ContPaq-proPDF AI Service Windows Service.
 
 .DESCRIPTION
     This script stops and removes the AI service from Windows Services
@@ -40,8 +40,8 @@ param(
 # Configuration
 # =============================================================================
 
-$ServiceName = "ContPAQWinAIService"
-$LogDirectory = "$env:PROGRAMDATA\ContPAQ-Win\logs"
+$ServiceName = "ContPaqProPDFAIService"
+$LogDirectory = "$env:PROGRAMDATA\ContPaq-proPDF\logs"
 
 # =============================================================================
 # Functions
@@ -86,7 +86,7 @@ function Test-ServiceExists {
 # Main Script
 # =============================================================================
 
-Write-Log "ContPAQ-Win AI Service Uninstaller"
+Write-Log "ContPaq-proPDF AI Service Uninstaller"
 Write-Log "==================================="
 
 # Check if service exists

--- a/ai-service/src/config.py
+++ b/ai-service/src/config.py
@@ -1,5 +1,5 @@
 """
-ContPAQ-Win AI Service - Configuration Module
+ContPaq-proPDF AI Service - Configuration Module
 
 This module provides type-safe configuration management using Pydantic Settings.
 Configuration values can be set via:

--- a/ai-service/src/utils/logging_config.py
+++ b/ai-service/src/utils/logging_config.py
@@ -1,5 +1,5 @@
 """
-ContPAQ-Win AI Service - JSON Logging Configuration
+ContPaq-proPDF AI Service - JSON Logging Configuration
 
 This module provides structured JSON logging for the AI service.
 All logs are output in JSON format for easy parsing and analysis.
@@ -37,7 +37,7 @@ DEFAULT_LOG_LEVEL = "INFO"
 DEFAULT_LOG_FORMAT = "json"
 LOG_FILE_MAX_BYTES = 10 * 1024 * 1024  # 10 MB
 LOG_FILE_BACKUP_COUNT = 5
-APP_NAME = "ContPAQ-Win"
+APP_NAME = "ContPaq-proPDF"
 SERVICE_NAME = "ai-service"
 
 
@@ -124,7 +124,7 @@ def get_log_directory() -> Path:
     """
     Get the log directory path.
 
-    On Windows, logs are stored in %LOCALAPPDATA%/ContPAQ-Win/Logs
+    On Windows, logs are stored in %LOCALAPPDATA%/ContPaq-proPDF/Logs
     On other platforms, logs are stored in ~/.contpaq-win/logs
 
     Returns:

--- a/build.ps1
+++ b/build.ps1
@@ -1,9 +1,9 @@
 <#
 .SYNOPSIS
-    Build script for ContPAQ-Win installer.
+    Build script for ContPaq-proPDF installer.
 
 .DESCRIPTION
-    This script automates the complete build process for ContPAQ-Win:
+    This script automates the complete build process for ContPaq-proPDF:
     1. Checks for required tools (Python, Node.js, .NET SDK, Inno Setup)
     2. Builds the AI Service executable (PyInstaller)
     3. Builds the Windows Bridge (.NET publish)
@@ -352,7 +352,7 @@ function Build-DesktopApp {
         Write-Log "Packaging with Electron Builder..."
         npm run package
 
-        $appPath = "release\win-unpacked\ContPAQ Win.exe"
+        $appPath = "release\win-unpacked\ContPaq proPDF.exe"
         if (Test-Path $appPath) {
             Write-Log "Desktop App built: release\win-unpacked\" "SUCCESS"
         }
@@ -439,7 +439,7 @@ $startTime = Get-Date
 
 Write-Host ""
 Write-Host "╔══════════════════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
-Write-Host "║                    ContPAQ-Win Build Script                          ║" -ForegroundColor Cyan
+Write-Host "║                    ContPaq-proPDF Build Script                          ║" -ForegroundColor Cyan
 Write-Host "╚══════════════════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
 Write-Host ""
 

--- a/desktop-app/electron-builder.json
+++ b/desktop-app/electron-builder.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/electron-userland/electron-builder/master/packages/app-builder-lib/scheme.json",
   "appId": "com.contpaq.win",
-  "productName": "ContPAQ Win",
-  "copyright": "Copyright © 2024 ContPAQ Win",
+  "productName": "ContPaq proPDF",
+  "copyright": "Copyright © 2024 ContPaq proPDF",
   "asar": true,
   "asarUnpack": [
     "**/*.node",
@@ -49,7 +49,7 @@
     ],
     "icon": "build/icon.ico",
     "artifactName": "${productName}-${version}-Setup.${ext}",
-    "publisherName": "ContPAQ Win"
+    "publisherName": "ContPaq proPDF"
   },
   "nsis": {
     "oneClick": false,
@@ -61,7 +61,7 @@
     "installerHeaderIcon": "build/icon.ico",
     "createDesktopShortcut": true,
     "createStartMenuShortcut": true,
-    "shortcutName": "ContPAQ Win",
+    "shortcutName": "ContPaq proPDF",
     "license": "LICENSE.txt",
     "language": "1034"
   },

--- a/desktop-app/package.json
+++ b/desktop-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contpaq-win-desktop",
   "version": "0.1.0",
-  "description": "ContPAQ-Win Desktop Application - AI-powered invoice processing for ContPAQi integration",
+  "description": "ContPaq-proPDF Desktop Application - AI-powered invoice processing for ContPAQi integration",
   "main": "dist/main/index.js",
   "scripts": {
     "start": "electron .",
@@ -47,11 +47,11 @@
     "typescript": "^5.3.0",
     "vite": "^5.0.0"
   },
-  "author": "ContPAQ-Win Team",
+  "author": "ContPaq-proPDF Team",
   "license": "MIT",
   "build": {
     "appId": "com.contpaq.win",
-    "productName": "ContPAQ-Win",
+    "productName": "ContPaq-proPDF",
     "directories": {
       "output": "release"
     },

--- a/desktop-app/src/main/index.ts
+++ b/desktop-app/src/main/index.ts
@@ -1,5 +1,5 @@
 /**
- * ContPAQ Win - Electron Main Process Entry Point
+ * ContPaq proPDF - Electron Main Process Entry Point
  *
  * This is the main entry point for the Electron application.
  * It creates and manages the browser window, handles lifecycle events,
@@ -25,7 +25,7 @@ function createWindow(): void {
     height: 800,
     minWidth: 800,
     minHeight: 600,
-    title: 'ContPAQ Win',
+    title: 'ContPaq proPDF',
     show: false, // Don't show until ready-to-show
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),

--- a/desktop-app/src/renderer/App.tsx
+++ b/desktop-app/src/renderer/App.tsx
@@ -1,5 +1,5 @@
 /**
- * ContPAQ Win - Main Application Component
+ * ContPaq proPDF - Main Application Component
  *
  * This is the root component that sets up routing and the main
  * application layout using React Router and Tailwind CSS.
@@ -37,7 +37,7 @@ function App(): JSX.Element {
           <nav className="flex items-center justify-between max-w-7xl mx-auto">
             <div className="flex items-center space-x-4">
               <h1 className="text-xl font-semibold text-primary-600">
-                ContPAQ Win
+                ContPaq proPDF
               </h1>
             </div>
             <div className="flex items-center space-x-4">

--- a/desktop-app/src/renderer/i18n/es.json
+++ b/desktop-app/src/renderer/i18n/es.json
@@ -1,6 +1,6 @@
 {
   "app": {
-    "name": "ContPAQ Win",
+    "name": "ContPaq proPDF",
     "description": "Sistema de gestión de facturas con extracción automática mediante IA",
     "version": "Versión"
   },

--- a/desktop-app/src/renderer/index.html
+++ b/desktop-app/src/renderer/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'" />
-    <meta name="description" content="ContPAQ Win - Sistema de gestión de facturas" />
-    <title>ContPAQ Win</title>
+    <meta name="description" content="ContPaq proPDF - Sistema de gestión de facturas" />
+    <title>ContPaq proPDF</title>
   </head>
   <body>
     <div id="root"></div>

--- a/desktop-app/src/renderer/pages/SettingsPage.tsx
+++ b/desktop-app/src/renderer/pages/SettingsPage.tsx
@@ -424,7 +424,7 @@ export function SettingsPage(): JSX.Element {
           <div className="space-y-4">
             {/* App Name and Version */}
             <div className="text-center pb-4 border-b border-gray-200">
-              <h3 className="text-xl font-bold text-gray-900">ContPAQ Win</h3>
+              <h3 className="text-xl font-bold text-gray-900">ContPaq proPDF</h3>
               <p className="text-sm text-gray-500">
                 Sistema de gestión de facturas con IA
               </p>

--- a/installer/INFO_ES.txt
+++ b/installer/INFO_ES.txt
@@ -1,7 +1,7 @@
-ContPAQ-Win - Instalación
+ContPaq-proPDF - Instalación
 =========================
 
-Gracias por elegir ContPAQ-Win para la gestión de sus facturas.
+Gracias por elegir ContPaq-proPDF para la gestión de sus facturas.
 
 REQUISITOS DEL SISTEMA
 ----------------------
@@ -16,7 +16,7 @@ COMPONENTES INCLUIDOS
 
 Esta instalación incluye:
 
-1. ContPAQ-Win Desktop
+1. ContPaq-proPDF Desktop
    Aplicación de escritorio para escanear y procesar facturas.
 
 2. Servicio de IA

--- a/installer/LICENSE_ES.txt
+++ b/installer/LICENSE_ES.txt
@@ -1,12 +1,12 @@
 ACUERDO DE LICENCIA DE SOFTWARE
-ContPAQ-Win
+ContPaq-proPDF
 
 Versión 0.1.0
 
 =============================================================================
 
 Por favor, lea atentamente este Acuerdo de Licencia de Software ("Licencia")
-antes de instalar o utilizar ContPAQ-Win ("Software").
+antes de instalar o utilizar ContPaq-proPDF ("Software").
 
 Al instalar o usar el Software, usted acepta los términos de esta Licencia.
 Si no está de acuerdo con los términos, no instale ni use el Software.
@@ -31,7 +31,7 @@ Usted NO puede:
 3. PROPIEDAD INTELECTUAL
 
 El Software y toda la documentación relacionada son propiedad exclusiva
-de ContPAQ-Win Team y están protegidos por las leyes de derechos de autor
+de ContPaq-proPDF Team y están protegidos por las leyes de derechos de autor
 y propiedad intelectual aplicables.
 
 4. COMPONENTES DE TERCEROS
@@ -87,4 +87,4 @@ Para preguntas sobre esta Licencia:
 Al hacer clic en "Acepto" o instalar el Software, usted reconoce que ha
 leído y comprendido este Acuerdo y acepta quedar vinculado por sus términos.
 
-© 2024 ContPAQ-Win Team. Todos los derechos reservados.
+© 2024 ContPaq-proPDF Team. Todos los derechos reservados.

--- a/installer/contpaq-win.iss
+++ b/installer/contpaq-win.iss
@@ -1,7 +1,7 @@
 ; =============================================================================
-; ContPAQ-Win Installer Script
+; ContPaq-proPDF Installer Script
 ; =============================================================================
-; T029.1 - Inno Setup installer for ContPAQ-Win application
+; T029.1 - Inno Setup installer for ContPaq-proPDF application
 ;
 ; This script creates a Windows installer that:
 ; - Installs the Electron desktop application
@@ -20,11 +20,11 @@
 ;   - Windows Bridge executable in windows-bridge/bin/publish
 ; =============================================================================
 
-#define MyAppName "ContPAQ-Win"
+#define MyAppName "ContPaq-proPDF"
 #define MyAppVersion "0.1.0"
-#define MyAppPublisher "ContPAQ-Win Team"
+#define MyAppPublisher "ContPaq-proPDF Team"
 #define MyAppURL "https://github.com/contpaq-win"
-#define MyAppExeName "ContPAQ Win.exe"
+#define MyAppExeName "ContPaq proPDF.exe"
 #define MyAppId "{{8B9E7A5C-4D3F-2E1B-0A9C-8D7E6F5A4B3C}"
 
 [Setup]
@@ -49,7 +49,7 @@ InfoBeforeFile=INFO_ES.txt
 
 ; Output settings
 OutputDir=output
-OutputBaseFilename=ContPAQ-Win-{#MyAppVersion}-Setup
+OutputBaseFilename=ContPaq-proPDF-{#MyAppVersion}-Setup
 SetupIconFile=assets\icon.ico
 UninstallDisplayIcon={app}\{#MyAppExeName}
 

--- a/installer/scripts/install-prerequisites.ps1
+++ b/installer/scripts/install-prerequisites.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-    Installs prerequisites for ContPAQ-Win application.
+    Installs prerequisites for ContPaq-proPDF application.
 
 .DESCRIPTION
     This script checks for and installs required prerequisites:
@@ -218,7 +218,7 @@ function Install-VCRedist {
 # Main Script
 # =============================================================================
 
-Write-Log "ContPAQ-Win Prerequisites Installer"
+Write-Log "ContPaq-proPDF Prerequisites Installer"
 Write-Log "===================================="
 Write-Log ""
 

--- a/installer/scripts/install-services.ps1
+++ b/installer/scripts/install-services.ps1
@@ -1,14 +1,14 @@
 <#
 .SYNOPSIS
-    Installs and starts ContPAQ-Win services.
+    Installs and starts ContPaq-proPDF services.
 
 .DESCRIPTION
     This script registers and starts the AI service and Windows Bridge
     as Windows services. It should be run after the main installation.
 
     Services installed:
-    - ContPAQWinAIService (AI Service via NSSM)
-    - ContPAQWinBridge (Windows Bridge as native service)
+    - ContPaqProPDFAIService (AI Service via NSSM)
+    - ContPaqProPDFBridge (Windows Bridge as native service)
 
 .PARAMETER InstallDir
     Installation directory. Default: Script location's parent.
@@ -36,17 +36,17 @@ if (-not $InstallDir) {
 }
 
 $NssmPath = Join-Path $InstallDir "tools\nssm.exe"
-$LogDir = "$env:PROGRAMDATA\ContPAQ-Win\logs"
+$LogDir = "$env:PROGRAMDATA\ContPaq-proPDF\logs"
 
 # AI Service configuration
-$AIServiceName = "ContPAQWinAIService"
+$AIServiceName = "ContPaqProPDFAIService"
 $AIServiceExe = Join-Path $InstallDir "ai-service\contpaq-ai-service.exe"
 $AIServiceHost = "127.0.0.1"
 $AIServicePort = "8000"
 
 # Windows Bridge configuration
-$BridgeServiceName = "ContPAQWinBridge"
-$BridgeServiceExe = Join-Path $InstallDir "windows-bridge\ContPAQWinBridge.exe"
+$BridgeServiceName = "ContPaqProPDFBridge"
+$BridgeServiceExe = Join-Path $InstallDir "windows-bridge\ContPaqProPDFBridge.exe"
 
 # =============================================================================
 # Functions
@@ -102,8 +102,8 @@ function Install-AIService {
     # Configure service
     & $NssmPath set $AIServiceName AppDirectory (Split-Path -Parent $AIServiceExe)
     & $NssmPath set $AIServiceName AppParameters "--host $AIServiceHost --port $AIServicePort"
-    & $NssmPath set $AIServiceName Description "ContPAQ-Win AI Service - Document processing with LayoutLMv3"
-    & $NssmPath set $AIServiceName DisplayName "ContPAQ-Win AI Service"
+    & $NssmPath set $AIServiceName Description "ContPaq-proPDF AI Service - Document processing with LayoutLMv3"
+    & $NssmPath set $AIServiceName DisplayName "ContPaq-proPDF AI Service"
     & $NssmPath set $AIServiceName Start SERVICE_AUTO_START
 
     # Restart configuration
@@ -149,7 +149,7 @@ function Install-BridgeService {
     $serviceParams = @{
         Name = $BridgeServiceName
         BinaryPathName = $BridgeServiceExe
-        DisplayName = "ContPAQ-Win Windows Bridge"
+        DisplayName = "ContPaq-proPDF Windows Bridge"
         Description = "API bridge for ContPAQi SDK integration"
         StartupType = "Automatic"
     }
@@ -172,7 +172,7 @@ function Install-BridgeService {
 function Start-Services {
     <#
     .SYNOPSIS
-        Start all ContPAQ-Win services.
+        Start all ContPaq-proPDF services.
     #>
     Write-Log "Starting services..."
 
@@ -204,7 +204,7 @@ function Start-Services {
 # Main Script
 # =============================================================================
 
-Write-Log "ContPAQ-Win Service Installer"
+Write-Log "ContPaq-proPDF Service Installer"
 Write-Log "=============================="
 Write-Log ""
 Write-Log "Install directory: $InstallDir"

--- a/installer/scripts/uninstall-services.ps1
+++ b/installer/scripts/uninstall-services.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-    Uninstalls ContPAQ-Win services.
+    Uninstalls ContPaq-proPDF services.
 
 .DESCRIPTION
     This script stops and removes the AI service and Windows Bridge
@@ -40,10 +40,10 @@ if (-not $InstallDir) {
 }
 
 $NssmPath = Join-Path $InstallDir "tools\nssm.exe"
-$LogDir = "$env:PROGRAMDATA\ContPAQ-Win\logs"
+$LogDir = "$env:PROGRAMDATA\ContPaq-proPDF\logs"
 
-$AIServiceName = "ContPAQWinAIService"
-$BridgeServiceName = "ContPAQWinBridge"
+$AIServiceName = "ContPaqProPDFAIService"
+$BridgeServiceName = "ContPaqProPDFBridge"
 
 # =============================================================================
 # Functions
@@ -137,7 +137,7 @@ function Remove-BridgeService {
 # Main Script
 # =============================================================================
 
-Write-Log "ContPAQ-Win Service Uninstaller"
+Write-Log "ContPaq-proPDF Service Uninstaller"
 Write-Log "================================"
 Write-Log ""
 

--- a/windows-bridge/scripts/install-service.ps1
+++ b/windows-bridge/scripts/install-service.ps1
@@ -1,7 +1,7 @@
 #Requires -RunAsAdministrator
 <#
 .SYNOPSIS
-    Installs the ContPAQ-Win Windows Bridge as a Windows Service.
+    Installs the ContPaq-proPDF Windows Bridge as a Windows Service.
 
 .DESCRIPTION
     This script registers the Windows Bridge .NET application as a Windows
@@ -10,7 +10,7 @@
     ContPAQi SDK.
 
 .PARAMETER ServicePath
-    Path to the ContPAQWinBridge.exe executable.
+    Path to the ContPaqProPDFBridge.exe executable.
     Default: Looks in the publish directory.
 
 .PARAMETER StartupType
@@ -20,7 +20,7 @@
     .\install-service.ps1
 
 .EXAMPLE
-    .\install-service.ps1 -ServicePath "C:\Program Files\ContPAQ-Win\bridge\ContPAQWinBridge.exe"
+    .\install-service.ps1 -ServicePath "C:\Program Files\ContPaq-proPDF\bridge\ContPaqProPDFBridge.exe"
 
 .NOTES
     Requires Administrator privileges.
@@ -40,14 +40,14 @@ param(
 # Configuration
 # =============================================================================
 
-$ServiceName = "ContPAQWinBridge"
-$DisplayName = "ContPAQ-Win Windows Bridge"
-$Description = "Bridge service connecting ContPAQ-Win desktop application to ContPAQi SDK. Provides REST API for vendor management, entry creation, and duplicate checking."
+$ServiceName = "ContPaqProPDFBridge"
+$DisplayName = "ContPaq-proPDF Windows Bridge"
+$Description = "Bridge service connecting ContPaq-proPDF desktop application to ContPAQi SDK. Provides REST API for vendor management, entry creation, and duplicate checking."
 $Host = "127.0.0.1"
 $Port = "5000"
 
 # Log directory
-$LogDirectory = "$env:PROGRAMDATA\ContPAQ-Win\logs"
+$LogDirectory = "$env:PROGRAMDATA\ContPaq-proPDF\logs"
 
 # =============================================================================
 # Functions
@@ -74,9 +74,9 @@ function Find-Executable {
 
     $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
     $locations = @(
-        (Join-Path $ScriptDir "..\src\ContPAQWinBridge\bin\publish\win-x64\ContPAQWinBridge.exe"),
-        (Join-Path $ScriptDir "..\publish\ContPAQWinBridge.exe"),
-        "$env:ProgramFiles\ContPAQ-Win\bridge\ContPAQWinBridge.exe"
+        (Join-Path $ScriptDir "..\src\ContPaqProPDFBridge\bin\publish\win-x64\ContPaqProPDFBridge.exe"),
+        (Join-Path $ScriptDir "..\publish\ContPaqProPDFBridge.exe"),
+        "$env:ProgramFiles\ContPaq-proPDF\bridge\ContPaqProPDFBridge.exe"
     )
 
     foreach ($location in $locations) {
@@ -119,7 +119,7 @@ function Remove-ExistingService {
 # Main Script
 # =============================================================================
 
-Write-Log "ContPAQ-Win Windows Bridge Service Installer"
+Write-Log "ContPaq-proPDF Windows Bridge Service Installer"
 Write-Log "============================================="
 Write-Log ""
 

--- a/windows-bridge/scripts/uninstall-service.ps1
+++ b/windows-bridge/scripts/uninstall-service.ps1
@@ -1,7 +1,7 @@
 #Requires -RunAsAdministrator
 <#
 .SYNOPSIS
-    Uninstalls the ContPAQ-Win Windows Bridge Windows Service.
+    Uninstalls the ContPaq-proPDF Windows Bridge Windows Service.
 
 .DESCRIPTION
     This script stops and removes the Windows Bridge service from Windows.
@@ -32,8 +32,8 @@ param(
 # Configuration
 # =============================================================================
 
-$ServiceName = "ContPAQWinBridge"
-$LogDirectory = "$env:PROGRAMDATA\ContPAQ-Win\logs"
+$ServiceName = "ContPaqProPDFBridge"
+$LogDirectory = "$env:PROGRAMDATA\ContPaq-proPDF\logs"
 
 # =============================================================================
 # Functions
@@ -61,7 +61,7 @@ function Test-ServiceExists {
 # Main Script
 # =============================================================================
 
-Write-Log "ContPAQ-Win Windows Bridge Service Uninstaller"
+Write-Log "ContPaq-proPDF Windows Bridge Service Uninstaller"
 Write-Log "==============================================="
 Write-Log ""
 

--- a/windows-bridge/src/ContPAQWinBridge/Configuration/LoggingConfiguration.cs
+++ b/windows-bridge/src/ContPAQWinBridge/Configuration/LoggingConfiguration.cs
@@ -10,14 +10,14 @@ namespace ContPAQWinBridge.Configuration;
 /// Provides centralized logging configuration for the Windows Bridge service
 /// with JSON output format, file rotation, and enrichment.
 ///
-/// Log files are stored in: %LOCALAPPDATA%\ContPAQ-Win\Logs\
+/// Log files are stored in: %LOCALAPPDATA%\ContPaq-proPDF\Logs\
 /// </summary>
 public static class LoggingConfiguration
 {
     /// <summary>
     /// Application name used in log paths.
     /// </summary>
-    public const string AppName = "ContPAQ-Win";
+    public const string AppName = "ContPaq-proPDF";
 
     /// <summary>
     /// Service name for log identification.
@@ -37,7 +37,7 @@ public static class LoggingConfiguration
     /// <summary>
     /// Gets the log directory path.
     ///
-    /// On Windows, logs are stored in %LOCALAPPDATA%\ContPAQ-Win\Logs
+    /// On Windows, logs are stored in %LOCALAPPDATA%\ContPaq-proPDF\Logs
     /// On other platforms, falls back to current directory.
     /// </summary>
     /// <returns>The full path to the log directory.</returns>

--- a/windows-bridge/src/ContPAQWinBridge/ContPAQWinBridge.csproj
+++ b/windows-bridge/src/ContPAQWinBridge/ContPAQWinBridge.csproj
@@ -8,9 +8,9 @@
     <AssemblyName>ContPAQWinBridge</AssemblyName>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>1.0.0</Version>
-    <Authors>ContPAQ Win Team</Authors>
+    <Authors>ContPaq proPDF Team</Authors>
     <Description>Windows Bridge service for ContPAQi SDK integration</Description>
-    <Product>ContPAQ Win</Product>
+    <Product>ContPaq proPDF</Product>
     <Copyright>Copyright © 2025</Copyright>
   </PropertyGroup>
 

--- a/windows-bridge/src/ContPAQWinBridge/Program.cs
+++ b/windows-bridge/src/ContPAQWinBridge/Program.cs
@@ -8,7 +8,7 @@ Log.Logger = new LoggerConfiguration()
     .WriteTo.Console(new CompactJsonFormatter())
     .CreateBootstrapLogger();
 
-Log.Information("Starting ContPAQ Win Bridge service...");
+Log.Information("Starting ContPaq proPDF Bridge service...");
 
 try
 {
@@ -49,7 +49,7 @@ try
     {
         options.SwaggerDoc("v1", new Microsoft.OpenApi.Models.OpenApiInfo
         {
-            Title = "ContPAQ Win Bridge API",
+            Title = "ContPaq proPDF Bridge API",
             Version = "v1",
             Description = "Windows Bridge service for ContPAQi SDK integration"
         });
@@ -65,7 +65,7 @@ try
     app.UseSwagger();
     app.UseSwaggerUI(options =>
     {
-        options.SwaggerEndpoint("/swagger/v1/swagger.json", "ContPAQ Win Bridge API v1");
+        options.SwaggerEndpoint("/swagger/v1/swagger.json", "ContPaq proPDF Bridge API v1");
         options.RoutePrefix = "swagger";
     });
 
@@ -75,12 +75,12 @@ try
     app.MapControllers();
     app.MapHealthChecks("/health");
 
-    Log.Information("ContPAQ Win Bridge service started successfully");
+    Log.Information("ContPaq proPDF Bridge service started successfully");
     app.Run();
 }
 catch (Exception ex)
 {
-    Log.Fatal(ex, "ContPAQ Win Bridge service terminated unexpectedly");
+    Log.Fatal(ex, "ContPaq proPDF Bridge service terminated unexpectedly");
 }
 finally
 {


### PR DESCRIPTION
Rename the application throughout the codebase:
- Update README files and documentation
- Update installer scripts and configuration
- Update desktop app package.json and electron-builder.json
- Update service install/uninstall scripts
- Update Python AI service configuration
- Update .NET Windows Bridge configuration
- Update UI components and i18n strings
- Update service names: ContPAQWin* -> ContPaqProPDF*