### PR TITLE
fix: add Vite config and skip optional deps for CI build

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -154,12 +154,14 @@ jobs:
         working-directory: desktop-app
         run: |
           Write-Host "Installing npm dependencies..."
-          npm ci
+          # Skip optional dependencies (canvas) which require native compilation
+          npm ci --ignore-optional
 
           Write-Host "Building application..."
           npm run build
 
           Write-Host "Packaging with Electron Builder..."
+          # electron-builder will rebuild native modules (better-sqlite3) for Electron
           npm run package
 
           # Find the built app

--- a/desktop-app/.npmrc
+++ b/desktop-app/.npmrc
@@ -1,0 +1,6 @@
+# Skip optional dependencies (e.g., canvas for react-pdf server-side rendering)
+# Canvas is not needed in Electron/browser environments
+optional=false
+
+# Use legacy peer deps for compatibility
+legacy-peer-deps=true

--- a/desktop-app/vite.config.ts
+++ b/desktop-app/vite.config.ts
@@ -1,0 +1,47 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+
+  // Set root to src/renderer where index.html is located
+  root: path.resolve(__dirname, 'src/renderer'),
+
+  // Base path for production builds
+  base: './',
+
+  build: {
+    // Output to dist/renderer relative to project root
+    outDir: path.resolve(__dirname, 'dist/renderer'),
+    emptyOutDir: true,
+
+    // Generate sourcemaps for debugging
+    sourcemap: true,
+
+    rollupOptions: {
+      // Externalize electron and node modules
+      external: ['electron', 'better-sqlite3'],
+    },
+  },
+
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+      '@renderer': path.resolve(__dirname, 'src/renderer'),
+      '@main': path.resolve(__dirname, 'src/main'),
+    },
+  },
+
+  // Optimize dependencies
+  optimizeDeps: {
+    exclude: ['electron', 'better-sqlite3'],
+  },
+
+  // Server configuration for development
+  server: {
+    port: 5173,
+    strictPort: true,
+  },
+});


### PR DESCRIPTION
- Create vite.config.ts with root pointing to src/renderer
- Add .npmrc to skip optional dependencies (canvas)
- Update workflow to use --ignore-optional flag