### PR TITLE
fix: remove optional=false to allow rollup binaries to install

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -154,14 +154,13 @@ jobs:
         working-directory: desktop-app
         run: |
           Write-Host "Installing npm dependencies..."
-          # Skip optional dependencies (canvas) which require native compilation
-          npm ci --ignore-optional
+          # Canvas may fail to build (optional dep) but npm will continue
+          npm ci
 
           Write-Host "Building application..."
           npm run build
 
           Write-Host "Packaging with Electron Builder..."
-          # electron-builder will rebuild native modules (better-sqlite3) for Electron
           npm run package
 
           # Find the built app

--- a/desktop-app/.npmrc
+++ b/desktop-app/.npmrc
@@ -1,6 +1,2 @@
-# Skip optional dependencies (e.g., canvas for react-pdf server-side rendering)
-# Canvas is not needed in Electron/browser environments
-optional=false
-
 # Use legacy peer deps for compatibility
 legacy-peer-deps=true


### PR DESCRIPTION
The previous fix broke rollup by skipping its platform-specific binaries. Canvas failures should be handled gracefully by npm since it's an optional dependency.