### PR TITLE
fix: add missing CSS and exclude canvas from electron build

### DIFF
--- a/desktop-app/electron-builder.json
+++ b/desktop-app/electron-builder.json
@@ -10,13 +10,16 @@
   ],
   "compression": "maximum",
   "npmRebuild": true,
+  "buildDependenciesFromSource": false,
   "directories": {
     "output": "release",
     "buildResources": "build"
   },
   "files": [
     "dist/**/*",
-    "package.json"
+    "package.json",
+    "!**/canvas/**",
+    "!**/canvas"
   ],
   "extraResources": [
     {

--- a/desktop-app/postcss.config.js
+++ b/desktop-app/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/desktop-app/src/renderer/styles/index.css
+++ b/desktop-app/src/renderer/styles/index.css
@@ -1,0 +1,57 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* Base styles for ContPaq-proPDF */
+@layer base {
+  html {
+    font-family: 'Inter', system-ui, sans-serif;
+  }
+
+  body {
+    @apply bg-gray-50 text-gray-900 antialiased;
+  }
+
+  /* Custom scrollbar */
+  ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  ::-webkit-scrollbar-track {
+    @apply bg-gray-100;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    @apply bg-gray-300 rounded-full;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    @apply bg-gray-400;
+  }
+}
+
+@layer components {
+  /* Button variants */
+  .btn {
+    @apply px-4 py-2 rounded-lg font-medium transition-colors duration-200;
+  }
+
+  .btn-primary {
+    @apply bg-primary-600 text-white hover:bg-primary-700;
+  }
+
+  .btn-secondary {
+    @apply bg-gray-200 text-gray-800 hover:bg-gray-300;
+  }
+
+  /* Card component */
+  .card {
+    @apply bg-white rounded-xl shadow-soft p-6;
+  }
+
+  /* Input styles */
+  .input {
+    @apply w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none transition-shadow;
+  }
+}


### PR DESCRIPTION
- Create src/renderer/styles/index.css with Tailwind directives
- Add postcss.config.js for Tailwind CSS processing
- Exclude canvas from electron-builder files (not needed in browser)
- Add buildDependenciesFromSource: false to skip native rebuilds