### PR TITLE
fix: add tsconfig.main.json and remove canvas before electron build

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -181,6 +181,12 @@ jobs:
           Write-Host "Building application..."
           npm run build
 
+          Write-Host "Removing canvas from node_modules (not needed in Electron, causes rebuild issues)..."
+          if (Test-Path "node_modules/canvas") {
+            Remove-Item -Recurse -Force "node_modules/canvas"
+            Write-Host "canvas removed successfully"
+          }
+
           Write-Host "Packaging with Electron Builder..."
           npm run package
 

--- a/desktop-app/tsconfig.main.json
+++ b/desktop-app/tsconfig.main.json
@@ -1,0 +1,48 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "CommonJS",
+    "moduleResolution": "node",
+
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+
+    "declaration": false,
+    "sourceMap": true,
+
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "@main/*": ["src/main/*"]
+    },
+
+    "outDir": "dist/main",
+    "rootDir": "src/main"
+  },
+  "include": [
+    "src/main/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "release"
+  ]
+}


### PR DESCRIPTION
- Create tsconfig.main.json for Electron main process compilation
- Remove canvas from node_modules before electron-builder runs (canvas causes rebuild failures and is not needed in browser context)