### PR TITLE
ci: add installer asset downloads (NSSM, icon, Tesseract)

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -218,6 +218,79 @@ jobs:
 
           Write-Host "Version updated successfully"
 
+      - name: Prepare installer assets
+        shell: pwsh
+        run: |
+          # Create installer directories
+          New-Item -ItemType Directory -Path "installer/tools" -Force | Out-Null
+          New-Item -ItemType Directory -Path "installer/assets" -Force | Out-Null
+
+          # Download NSSM (Non-Sucking Service Manager)
+          Write-Host "Downloading NSSM..."
+          $nssmUrl = "https://nssm.cc/release/nssm-2.24.zip"
+          $nssmZip = "$env:TEMP\nssm.zip"
+          Invoke-WebRequest -Uri $nssmUrl -OutFile $nssmZip -UseBasicParsing
+          Expand-Archive -Path $nssmZip -DestinationPath "$env:TEMP\nssm" -Force
+          Copy-Item "$env:TEMP\nssm\nssm-2.24\win64\nssm.exe" "installer/tools/nssm.exe"
+          Write-Host "NSSM downloaded successfully"
+
+          # Create a simple icon file (use a system icon or create placeholder)
+          # For now, copy from Electron build if available, otherwise create minimal ICO
+          $electronIcon = "desktop-app/build/icon.ico"
+          $installerIcon = "installer/assets/icon.ico"
+
+          if (Test-Path $electronIcon) {
+            Copy-Item $electronIcon $installerIcon
+            Write-Host "Copied icon from Electron build"
+          } else {
+            # Create a minimal valid ICO file (16x16 blank icon)
+            Write-Host "Creating placeholder icon..."
+            $icoHeader = [byte[]](0,0,1,0,1,0,16,16,0,0,1,0,32,0,104,4,0,0,22,0,0,0)
+            $bmpHeader = [byte[]](40,0,0,0,16,0,0,0,32,0,0,0,1,0,32,0,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)
+            $pixelData = New-Object byte[] 1024  # 16x16x4 bytes (BGRA)
+            # Fill with a blue color
+            for ($i = 0; $i -lt 1024; $i += 4) {
+              $pixelData[$i] = 0xC7     # B
+              $pixelData[$i+1] = 0x84   # G
+              $pixelData[$i+2] = 0x02   # R
+              $pixelData[$i+3] = 0xFF   # A
+            }
+            $andMask = New-Object byte[] 64  # 16x16/8 * 2 rows
+
+            $fs = [System.IO.File]::Create($installerIcon)
+            $fs.Write($icoHeader, 0, $icoHeader.Length)
+            $fs.Write($bmpHeader, 0, $bmpHeader.Length)
+            $fs.Write($pixelData, 0, $pixelData.Length)
+            $fs.Write($andMask, 0, $andMask.Length)
+            $fs.Close()
+            Write-Host "Created placeholder icon"
+          }
+
+          # Download Tesseract OCR
+          Write-Host "Downloading Tesseract OCR..."
+          $tesseractDir = "desktop-app/resources/tesseract"
+          New-Item -ItemType Directory -Path $tesseractDir -Force | Out-Null
+
+          # Download Tesseract portable from UB-Mannheim
+          $tesseractUrl = "https://digi.bib.uni-mannheim.de/tesseract/tesseract-ocr-w64-setup-5.3.3.20231005.exe"
+          $tesseractInstaller = "$env:TEMP\tesseract-installer.exe"
+
+          Write-Host "Downloading Tesseract installer..."
+          Invoke-WebRequest -Uri $tesseractUrl -OutFile $tesseractInstaller -UseBasicParsing
+
+          Write-Host "Extracting Tesseract (silent install to temp)..."
+          $tesseractInstallDir = "$env:TEMP\tesseract"
+          Start-Process -FilePath $tesseractInstaller -ArgumentList "/S", "/D=$tesseractInstallDir" -Wait
+
+          Write-Host "Copying Tesseract files..."
+          if (Test-Path $tesseractInstallDir) {
+            Copy-Item "$tesseractInstallDir\*" $tesseractDir -Recurse -Force
+            Write-Host "Tesseract copied successfully"
+          } else {
+            Write-Host "Warning: Tesseract extraction failed, creating placeholder"
+            New-Item -ItemType File -Path "$tesseractDir/placeholder.txt" -Force | Out-Null
+          }
+
       # =========================================
       # Build Installer
       # =========================================

--- a/installer/contpaq-win.iss
+++ b/installer/contpaq-win.iss
@@ -90,8 +90,8 @@ Source: "..\ai-service\dist\*"; DestDir: "{app}\ai-service"; Flags: ignoreversio
 ; Windows Bridge
 Source: "..\windows-bridge\src\ContPAQWinBridge\bin\publish\win-x64\*"; DestDir: "{app}\windows-bridge"; Flags: ignoreversion recursesubdirs createallsubdirs
 
-; Tesseract OCR
-Source: "..\desktop-app\resources\tesseract\*"; DestDir: "{app}\tesseract"; Flags: ignoreversion recursesubdirs createallsubdirs
+; Tesseract OCR (optional - may not be present in all builds)
+Source: "..\desktop-app\resources\tesseract\*"; DestDir: "{app}\tesseract"; Flags: ignoreversion recursesubdirs createallsubdirs skipifsourcedoesntexist
 
 ; NSSM for AI service
 Source: "tools\nssm.exe"; DestDir: "{app}\tools"; Flags: ignoreversion


### PR DESCRIPTION
- Download NSSM service manager during CI build
- Create placeholder icon if electron build icon not present
- Download Tesseract OCR during CI build
- Make tesseract files optional in installer script